### PR TITLE
Model changes

### DIFF
--- a/MIABIS_on_FHIR/MoF_collection.py
+++ b/MIABIS_on_FHIR/MoF_collection.py
@@ -15,52 +15,39 @@ from fhirclient.models.range import Range
 from MIABIS_on_FHIR.gender import MoFGender
 from MIABIS_on_FHIR.incorrect_json_format import IncorrectJsonFormatException
 from MIABIS_on_FHIR.storage_temperature import MoFStorageTemperature
-from _constants import COLLECTION_DESIGN, COLLECTION_SAMPLE_COLLECTION_SETTING, COLLECTION_SAMPLE_SOURCE, \
-    COLLECTION_DATASET_TYPE, COLLECTION_INCLUSION_CRITERIA, COLLECTION_USE_AND_ACCESS_CONDITIONS, MATERIAL_TYPE_CODES, \
-    DEFINITION_BASE_URL
+from _constants import COLLECTION_INCLUSION_CRITERIA, MATERIAL_TYPE_CODES, DEFINITION_BASE_URL
 
 
 class MoFCollection:
     """Sample Collection represents a set of samples with at least one common characteristic."""
 
     # TODO age range units
-    def __init__(self, identifier: str, name: str, managing_biobank_id: str,
+    def __init__(self, identifier: str, name: str, managing_collection_org_id: str,
                  age_range_low: int,
                  age_range_high: int, genders: list[MoFGender], storage_temperatures: list[MoFStorageTemperature],
-                 material_types: list[str], description: str = None, diagnoses: list[str] = None,
-                 dataset_type: str = None,
-                 sample_source: str = None,
-                 sample_collection_setting: str = None, collection_design: list[str] = None,
-                 use_and_access_conditions: list[str] = None,
-                 number_of_subjects: int = None, inclusion_criteria: list[str] = None, publications: list[str] = None):
+                 material_types: list[str], diagnoses: list[str] = None, number_of_subjects: int = None,
+                 inclusion_criteria: list[str] = None, sample_ids: list[str] = None, ):
         """
         :param identifier: Collection identifier same format as in the BBMRI-ERIC directory.
         :param name: Name of the collection.
         :param description: Description of the collection.
-        :param managing_biobank_id: Identifier of the biobank managing the collection.
+        :param managing_biobank_id: Identifier of the collection-organization resource.
         :param age_range_low: Lower bound of the age range of the subjects in the collection.
         :param age_range_high: Upper bound of the age range of the subjects in the collection.
         :param genders: List of genders of the subjects in the collection.
         :param storage_temperatures: List of storage temperatures of the samples in the collection.
         :param material_types: List of material types of the samples in the collection.
         :param diagnoses: List of diagnoses of the subjects in the collection.
-        :param dataset_type: Type of the dataset. Available values in the _constants.py file
-        :param sample_source: Source of the samples. Available values in the _constants.py file
-        :param sample_collection_setting: Setting of the sample collection. Available values in the _constants.py file
-        :param collection_design: Design of the collection. Available values in the _constants.py file
-        :param use_and_access_conditions: Conditions for use and access of the collection.
          Available values in the _constants.py file
         :param number_of_subjects: Number of subjects in the collection.
         :param inclusion_criteria: Inclusion criteria for the subjects in the collection.
-        :param publications: Publications related to the collection.
+        :param sample_ids: List of sample identifiers belonging to the collection.
         """
         if not isinstance(identifier, str):
             raise TypeError("Collection identifier must be a string.")
         if not isinstance(name, str):
             raise TypeError("Collection name must be a string.")
-        if description is not None and not isinstance(description, str):
-            raise TypeError("Collection description must be a string.")
-        if not isinstance(managing_biobank_id, str):
+        if not isinstance(managing_collection_org_id, str):
             raise TypeError("Managing biobank identifier must be a string.")
         if not isinstance(age_range_low, int):
             raise TypeError("Age range low must be an integer.")
@@ -75,55 +62,36 @@ class MoFCollection:
         for material_type in material_types:
             if material_type not in MATERIAL_TYPE_CODES:
                 raise ValueError(f"{material_type} is not a valid code for material type")
+        if sample_ids is not None:
+            for sample_id in sample_ids:
+                if not isinstance(sample_id, str):
+                    raise TypeError("Sample id must be a string.")
 
-        self._identifier: str = identifier
-        self._name: str = name
-        self._description: str = description
-        self._managing_biobank_id: str = managing_biobank_id
-        self._age_range_low: int = age_range_low
-        self._age_range_high: int = age_range_high
-        self._genders = genders
-        self._storage_temperatures = storage_temperatures
-        self._material_types = material_types
         if diagnoses is not None:
             for diagnosis in diagnoses:
                 if not icd10.exists(diagnosis):
                     raise TypeError("The provided string is not a valid ICD-10 code.")
-        self._diagnoses = diagnoses
 
-        if dataset_type is not None and dataset_type not in COLLECTION_DATASET_TYPE:
-            raise ValueError(f"{dataset_type} is not a valid code for dataset type")
-        self._dataset_type = dataset_type
-
-        if sample_source is not None and sample_source not in COLLECTION_SAMPLE_SOURCE:
-            raise ValueError(f"{sample_source} is not a valid code for sample source")
-        self._sample_source = sample_source
-
-        if sample_collection_setting is not None and sample_collection_setting \
-                not in COLLECTION_SAMPLE_COLLECTION_SETTING:
-            raise ValueError(f"{sample_collection_setting} is not a valid code for sample collection setting")
-        self._sample_collection_setting = sample_collection_setting
-
-        if collection_design is not None:
-            for design in collection_design:
-                if design not in COLLECTION_DESIGN:
-                    raise ValueError(f"{design} is not a valid code for collection design")
-        self._collection_design = collection_design
-
-        if use_and_access_conditions is not None:
-            for condition in use_and_access_conditions:
-                if condition not in COLLECTION_USE_AND_ACCESS_CONDITIONS:
-                    raise ValueError(f"{condition} is not a valid code for use and access conditions")
-        self._use_and_access_conditions = use_and_access_conditions
         if number_of_subjects is not None and not isinstance(number_of_subjects, int):
             raise TypeError("Number of subjects must be an integer.")
-        self._number_of_subjects = number_of_subjects
+
         if inclusion_criteria is not None:
             for inclusion in inclusion_criteria:
                 if inclusion not in COLLECTION_INCLUSION_CRITERIA:
                     raise ValueError(f"{inclusion} is not a valid code for inclusion criteria")
+
+        self._identifier: str = identifier
+        self._name: str = name
+        self._managing_collection_org_id: str = managing_collection_org_id
+        self._age_range_low: int = age_range_low
+        self._age_range_high: int = age_range_high
+        self._genders = genders
+        self._storage_temperatures = storage_temperatures
+        self._diagnoses = diagnoses
+        self._material_types = material_types
+        self._number_of_subjects = number_of_subjects
+        self._sample_ids = sample_ids
         self._inclusion_criteria = inclusion_criteria
-        self._publications = publications
 
     @property
     def identifier(self) -> str:
@@ -146,24 +114,14 @@ class MoFCollection:
         self._name = name
 
     @property
-    def description(self) -> str:
-        return self._description
+    def managing_collection_org_id(self) -> str:
+        return self._managing_collection_org_id
 
-    @description.setter
-    def description(self, description: str):
-        if description is not None and not isinstance(description, str):
-            raise TypeError("Collection description must be a string.")
-        self._description = description
-
-    @property
-    def managing_biobank_id(self) -> str:
-        return self._managing_biobank_id
-
-    @managing_biobank_id.setter
-    def managing_biobank_id(self, managing_biobank_id: str):
-        if not isinstance(managing_biobank_id, str):
+    @managing_collection_org_id.setter
+    def managing_collection_org_id(self, managing_collection_org_id: str):
+        if not isinstance(managing_collection_org_id, str):
             raise TypeError("Managing biobank identifier must be a string.")
-        self._managing_biobank_id = managing_biobank_id
+        self._managing_collection_org_id= managing_collection_org_id
 
     @property
     def age_range_low(self) -> int:
@@ -230,46 +188,6 @@ class MoFCollection:
         self._diagnoses = diagnoses
 
     @property
-    def dataset_type(self) -> str:
-        return self._dataset_type
-
-    @dataset_type.setter
-    def dataset_type(self, dataset_type: str):
-        self._dataset_type = dataset_type
-
-    @property
-    def sample_source(self) -> str:
-        return self._sample_source
-
-    @sample_source.setter
-    def sample_source(self, sample_source: str):
-        self._sample_source = sample_source
-
-    @property
-    def sample_collection_setting(self) -> str:
-        return self._sample_collection_setting
-
-    @sample_collection_setting.setter
-    def sample_collection_setting(self, sample_collection_setting: str):
-        self._sample_collection_setting = sample_collection_setting
-
-    @property
-    def collection_design(self) -> list[str]:
-        return self._collection_design
-
-    @collection_design.setter
-    def collection_design(self, collection_design: list[str]):
-        self._collection_design = collection_design
-
-    @property
-    def use_and_access_conditions(self) -> list[str]:
-        return self._use_and_access_conditions
-
-    @use_and_access_conditions.setter
-    def use_and_access_conditions(self, use_and_access_conditions: list[str]):
-        self._use_and_access_conditions = use_and_access_conditions
-
-    @property
     def number_of_subjects(self) -> int:
         return self._number_of_subjects
 
@@ -286,19 +204,23 @@ class MoFCollection:
         self._inclusion_criteria = inclusion_criteria
 
     @property
-    def publications(self) -> list[str]:
-        return self._publications
+    def sample_ids(self) -> list[str]:
+        return self._sample_ids
 
-    @publications.setter
-    def publications(self, publications: list[str]):
-        self._publications = publications
+    @sample_ids.setter
+    def sample_ids(self, sample_ids: list[str]):
+        for sample_id in sample_ids:
+            if not isinstance(sample_id, str):
+                raise TypeError("Sample id must be a string.")
+        self._sample_ids = sample_ids
 
     @classmethod
-    def from_json(cls, collection_json: dict, managing_biobank_id) -> Self:
+    def from_json(cls, collection_json: dict, managing_collection_organization_id: str, sample_ids: list[str]) -> Self:
         """
         Parse a JSON object into a MoFCollection object.
         :param collection_json: json object representing the collection.
-        :param managing_biobank_id: id of managing biobank usually given by the institution (not a FHIR id!)
+        :param managing_collection_organization_id: id of collection-organization usually given by the institution (not a FHIR id!)
+        :param sample_ids: list of sample ids belonging to the collection, given by the institution (not FHIR ids!)
         :return: MoFCollection object
         """
         try:
@@ -310,15 +232,8 @@ class MoFCollection:
             storage_temperatures = []
             material_types = []
             diagnoses = None
-            dataset_type = None
-            sample_source = None
-            sample_collection_setting = None
-            collection_design = None
-            use_and_access_conditions = None
             number_of_subjects = None
             inclusion_criteria = None
-            publications = None
-            description = None
             for characteristic in collection_json["characteristic"]:
                 match characteristic["code"]["coding"][0]["code"]:
                     case "Age":
@@ -344,47 +259,24 @@ class MoFCollection:
             extension = collection_json.get("extension", [])
             for ext in extension:
                 match ext["url"].replace(f"{DEFINITION_BASE_URL}/StructureDefinition/", "", 1):
-                    case "dataset-type-extension":
-                        dataset_type = ext["valueCodeableConcept"]["coding"][0]["code"]
-                    case "sample-source-extension":
-                        sample_source = ext["valueCodeableConcept"]["coding"][0]["code"]
-                    case "sample-collection-setting-extension":
-                        sample_collection_setting = ext["valueCodeableConcept"]["coding"][0]["code"]
-                    case "collection-design-extension":
-                        if collection_design is None:
-                            collection_design = []
-                        collection_design.append(ext["valueCodeableConcept"]["coding"][0]["code"])
-                    case "use-and-access-conditions-extension":
-                        if use_and_access_conditions is None:
-                            use_and_access_conditions = []
-                        use_and_access_conditions.append(ext["valueCodeableConcept"]["coding"][0]["code"])
                     case "number-of-subjects-extension":
                         number_of_subjects = ext["valueInteger"]
                     case "inclusion-criteria-extension":
                         if inclusion_criteria is None:
                             inclusion_criteria = []
                         inclusion_criteria.append(ext["valueCodeableConcept"]["coding"][0]["code"])
-                    case "publication-extension":
-                        if publications is None:
-                            publications = []
-                        publications.append(ext["valueString"])
-                    case "description-extension":
-                        description = ext["valueString"]
                     case _:
                         pass
-            return cls(identifier, name, managing_biobank_id, age_range_low, age_range_high, genders,
-                       storage_temperatures, material_types, description, diagnoses, dataset_type, sample_source,
-                       sample_collection_setting, collection_design, use_and_access_conditions, number_of_subjects,
-                       inclusion_criteria, publications)
-
-
-
+            return cls(identifier, name, managing_collection_organization_id, age_range_low, age_range_high, genders,
+                       storage_temperatures, material_types, diagnoses, number_of_subjects, inclusion_criteria,
+                       sample_ids)
         except KeyError:
             raise IncorrectJsonFormatException("Error occured when parsing json into MoFCollection")
 
-    def to_fhir(self, managing_organization_fhir_id: str) -> Group:
+    def to_fhir(self, managing_organization_fhir_id: str, sample_fhir_ids: list[str]) -> Group:
         """Return collection representation in FHIR
-        :param managing_organization_fhir_id: FHIR Identifier of the managing organization"""
+        :param managing_organization_fhir_id: FHIR Identifier of the managing organization
+        :param sample_fhir_ids: List of FHIR identifiers of the samples in the collection"""
         fhir_group = Group()
         fhir_group.meta = Meta()
         fhir_group.meta.profile = [DEFINITION_BASE_URL + "/StructureDefinition/Collection"]
@@ -407,30 +299,6 @@ class MoFCollection:
             for diagnosis in self.diagnoses:
                 fhir_group.characteristic.append(self.__create_diagnosis_characteristic(diagnosis))
         extensions = []
-        if self.dataset_type is not None:
-            extensions.append(self.__create_codeable_concept_extension(
-                DEFINITION_BASE_URL + "/StructureDefinition/dataset-type-extension",
-                DEFINITION_BASE_URL + "/datasetTypeCS",
-                self.dataset_type))
-        if self.sample_source is not None:
-            extensions.append(self.__create_codeable_concept_extension(
-                DEFINITION_BASE_URL + "/StructureDefinition/sample-source-extension",
-                DEFINITION_BASE_URL + "/sampleSourceCS",
-                self.sample_source))
-        if self.sample_collection_setting is not None:
-            extensions.append(self.__create_codeable_concept_extension(
-                DEFINITION_BASE_URL + "/StructureDefinition/sample-collection-setting-extension",
-                DEFINITION_BASE_URL + "/sampleCollectionSettingCS", self.sample_collection_setting))
-        if self.collection_design is not None:
-            for design in self.collection_design:
-                extensions.append(self.__create_codeable_concept_extension(
-                    DEFINITION_BASE_URL + "/StructureDefinition/collection-design-extension",
-                    DEFINITION_BASE_URL + "/collectionDesignCS", design))
-        if self.use_and_access_conditions is not None:
-            for condition in self.use_and_access_conditions:
-                extensions.append(self.__create_codeable_concept_extension(
-                    DEFINITION_BASE_URL + "/StructureDefinition/use-and-access-conditions-extension",
-                    DEFINITION_BASE_URL + "/useAndAccessConditionsCS", condition))
         if self.number_of_subjects is not None:
             extensions.append(self.__create_integer_extension(
                 DEFINITION_BASE_URL + "/StructureDefinition/number-of-subjects-extension", self.number_of_subjects))
@@ -439,16 +307,19 @@ class MoFCollection:
                 extensions.append(self.__create_codeable_concept_extension(
                     DEFINITION_BASE_URL + "/StructureDefinition/inclusion-criteria-extension",
                     DEFINITION_BASE_URL + "/inclusionCriteriaCS", criteria))
-        if self.publications is not None:
-            for publication in self.publications:
-                extensions.append(self.__create_string_extension(
-                    DEFINITION_BASE_URL + "/StructureDefinition/publication-extension", publication))
-        if self.description is not None:
-            extensions.append(self.__create_string_extension(
-                DEFINITION_BASE_URL + "/StructureDefinition/description-extension", self.description))
+        for sample_fhir_id in sample_fhir_ids:
+            extensions.append(self.__create_member_extension(sample_fhir_id))
         if extensions:
             fhir_group.extension = extensions
         return fhir_group
+
+
+    def __create_member_extension(self, sample_fhir_id: str):
+        extension = Extension()
+        extension.url = "http://hl7.org/fhir/5.0/StructureDefinition/extension-Group.member.entity"
+        extension.valueReference = FHIRReference()
+        extension.valueReference.reference = f"Specimen/{sample_fhir_id}"
+        return extension
 
     def __create_age_range_characteristic(self, age_low: int, age_high: int) -> GroupCharacteristic:
         # TODO add age range units

--- a/MIABIS_on_FHIR/MoF_collection_organization.py
+++ b/MIABIS_on_FHIR/MoF_collection_organization.py
@@ -1,0 +1,468 @@
+"""Module for handling SampleCollection operations"""
+from typing import Self
+
+from fhirclient.models.address import Address
+from fhirclient.models.codeableconcept import CodeableConcept
+from fhirclient.models.coding import Coding
+from fhirclient.models.contactpoint import ContactPoint
+from fhirclient.models.extension import Extension
+from fhirclient.models.fhirreference import FHIRReference
+from fhirclient.models.humanname import HumanName
+from fhirclient.models.identifier import Identifier
+from fhirclient.models.meta import Meta
+from fhirclient.models.organization import Organization, OrganizationContact
+
+from MIABIS_on_FHIR.incorrect_json_format import IncorrectJsonFormatException
+from _constants import COLLECTION_DESIGN, COLLECTION_SAMPLE_COLLECTION_SETTING, COLLECTION_SAMPLE_SOURCE, \
+    COLLECTION_DATASET_TYPE, COLLECTION_USE_AND_ACCESS_CONDITIONS, DEFINITION_BASE_URL
+
+
+class MoFCollectionOrganization:
+    """Sample Collection represents a set of samples with at least one common characteristic."""
+
+    # TODO age range units
+    def __init__(self, identifier: str, name: str, managing_biobank_id: str,
+                 contact_name: str, contact_surname: str,
+                 contact_email: str,
+                 country: str,
+                 alias: str = None,
+                 url: str = None,
+                 description: str = None,
+                 dataset_type: str = None,
+                 sample_source: str = None,
+                 sample_collection_setting: str = None, collection_design: list[str] = None,
+                 use_and_access_conditions: list[str] = None,
+                 publications: list[str] = None):
+        """
+        :param identifier: Collection identifier same format as in the BBMRI-ERIC directory.
+        :param name: Name of the collection.
+        :param managing_biobank_id: Identifier of the biobank managing the collection.
+        :param contact_name: Name of the contact person for the collection.
+        :param contact_surname: Surname of the contact person for the collection.
+        :param contact_email: Email of the contact person for the collection.
+        :param alias: Alias of the collection.
+        :param url: URL of the collection.
+        :param description: Description of the collection.
+        :param dataset_type: Type of the dataset. Available values in the _constants.py file
+        :param sample_source: Source of the samples. Available values in the _constants.py file
+        :param sample_collection_setting: Setting of the sample collection. Available values in the _constants.py file
+        :param collection_design: Design of the collection. Available values in the _constants.py file
+        :param use_and_access_conditions: Conditions for use and access of the collection.
+         Available values in the _constants.py file
+        :param publications: Publications related to the collection.
+        """
+        if not isinstance(identifier, str):
+            raise TypeError("Collection identifier must be a string.")
+        if not isinstance(name, str):
+            raise TypeError("Collection name must be a string.")
+        if description is not None and not isinstance(description, str):
+            raise TypeError("Collection description must be a string.")
+        if not isinstance(managing_biobank_id, str):
+            raise TypeError("Managing biobank identifier must be a string.")
+        if not isinstance(contact_name, str):
+            raise TypeError("Contact name must be a string.")
+        if not isinstance(contact_surname, str):
+            raise TypeError("Contact surname must be a string.")
+        if not isinstance(contact_email, str):
+            raise TypeError("Contact email must be a string.")
+        if not isinstance(country, str):
+            raise TypeError("Country must be a string.")
+        if alias is not None and not isinstance(alias, str):
+            raise TypeError("Collection alias must be a string.")
+        if url is not None and not isinstance(url, str):
+            raise TypeError("Collection URL must be a string.")
+        if publications is not None:
+            if not isinstance(publications, list):
+                raise TypeError("Publications must be a list.")
+            for publication in publications:
+                if not isinstance(publication, str):
+                    raise TypeError("Publications must be a list of strings.")
+
+
+        self._identifier: str = identifier
+        self._name: str = name
+        self._description: str = description
+        self._managing_biobank_id: str = managing_biobank_id
+        self._contact_name: str = contact_name
+        self._contact_surname: str = contact_surname
+        self._contact_email: str = contact_email
+        self._country = country
+        self._alias: str = alias
+        self._url: str = url
+
+        if dataset_type is not None and dataset_type not in COLLECTION_DATASET_TYPE:
+            raise ValueError(f"{dataset_type} is not a valid code for dataset type")
+        self._dataset_type = dataset_type
+
+        if sample_source is not None and sample_source not in COLLECTION_SAMPLE_SOURCE:
+            raise ValueError(f"{sample_source} is not a valid code for sample source")
+        self._sample_source = sample_source
+
+        if sample_collection_setting is not None and sample_collection_setting \
+                not in COLLECTION_SAMPLE_COLLECTION_SETTING:
+            raise ValueError(f"{sample_collection_setting} is not a valid code for sample collection setting")
+        self._sample_collection_setting = sample_collection_setting
+
+        if collection_design is not None:
+            if not isinstance(collection_design, list):
+                raise TypeError("Collection design must be a list")
+            for design in collection_design:
+                if design not in COLLECTION_DESIGN:
+                    raise ValueError(f"{design} is not a valid code for collection design")
+        self._collection_design = collection_design
+
+        if use_and_access_conditions is not None:
+            if not isinstance(use_and_access_conditions, list):
+                raise TypeError("Use and access conditions must be a list.")
+            for condition in use_and_access_conditions:
+                if condition not in COLLECTION_USE_AND_ACCESS_CONDITIONS:
+                    raise ValueError(f"{condition} is not a valid code for use and access conditions")
+        self._use_and_access_conditions = use_and_access_conditions
+        self._publications = publications
+
+    @property
+    def identifier(self) -> str:
+        return self._identifier
+
+    @identifier.setter
+    def identifier(self, identifier: str):
+        if not isinstance(identifier, str):
+            raise TypeError("Collection identifier must be a string.")
+        self._identifier = identifier
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @name.setter
+    def name(self, name: str):
+        if not isinstance(name, str):
+            raise TypeError("Collection name must be a string.")
+        self._name = name
+
+    @property
+    def description(self) -> str:
+        return self._description
+
+    @description.setter
+    def description(self, description: str):
+        if description is not None and not isinstance(description, str):
+            raise TypeError("Collection description must be a string.")
+        self._description = description
+
+    @property
+    def managing_biobank_id(self) -> str:
+        return self._managing_biobank_id
+
+    @managing_biobank_id.setter
+    def managing_biobank_id(self, managing_biobank_id: str):
+        if not isinstance(managing_biobank_id, str):
+            raise TypeError("Managing biobank identifier must be a string.")
+        self._managing_biobank_id = managing_biobank_id
+
+    @property
+    def contact_name(self) -> str:
+        return self._contact_name
+
+    @contact_name.setter
+    def contact_name(self, contact_name: str):
+        if not isinstance(contact_name, str):
+            raise TypeError("Contact name must be a string.")
+        self._contact_name = contact_name
+
+    @property
+    def contact_surname(self) -> str:
+        return self._contact_surname
+
+    @contact_surname.setter
+    def contact_surname(self, contact_surname: str):
+        if not isinstance(contact_surname, str):
+            raise TypeError("Contact surname must be a string.")
+        self._contact_surname = contact_surname
+
+    @property
+    def contact_email(self) -> str:
+        return self._contact_email
+
+    @contact_email.setter
+    def contact_email(self, contact_email: str):
+        if not isinstance(contact_email, str):
+            raise TypeError("Contact email must be a string.")
+        self._contact_email = contact_email
+
+    @property
+    def country(self) -> str:
+        return self._country
+
+    @country.setter
+    def country(self, country: str):
+        if not isinstance(country, str):
+            raise TypeError("Country must be a string.")
+        self._country = country
+
+    @property
+    def alias(self) -> str:
+        return self._alias
+
+    @alias.setter
+    def alias(self, alias: str):
+        if alias is not None and not isinstance(alias, str):
+            raise TypeError("Collection alias must be a string.")
+        self._alias = alias
+
+    @property
+    def url(self) -> str:
+        return self._url
+
+    @url.setter
+    def url(self, url: str):
+        if url is not None and not isinstance(url, str):
+            raise TypeError("Collection URL must be a string.")
+        self._url = url
+
+    @property
+    def dataset_type(self) -> str:
+        return self._dataset_type
+
+    @dataset_type.setter
+    def dataset_type(self, dataset_type: str):
+        if dataset_type is not None and dataset_type not in COLLECTION_DATASET_TYPE:
+            raise ValueError(f"{dataset_type} is not a valid code for dataset type")
+        self._dataset_type = dataset_type
+
+    @property
+    def sample_source(self) -> str:
+        return self._sample_source
+
+    @sample_source.setter
+    def sample_source(self, sample_source: str):
+        if sample_source is not None and sample_source not in COLLECTION_SAMPLE_SOURCE:
+            raise ValueError(f"{sample_source} is not a valid code for sample source")
+        self._sample_source = sample_source
+
+    @property
+    def sample_collection_setting(self) -> str:
+        return self._sample_collection_setting
+
+    @sample_collection_setting.setter
+    def sample_collection_setting(self, sample_collection_setting: str):
+        if sample_collection_setting is not None and \
+                sample_collection_setting not in COLLECTION_SAMPLE_COLLECTION_SETTING:
+            raise ValueError(f"{sample_collection_setting} is not a valid code for sample collection setting")
+        self._sample_collection_setting = sample_collection_setting
+
+    @property
+    def collection_design(self) -> list[str]:
+        return self._collection_design
+
+    @collection_design.setter
+    def collection_design(self, collection_design: list[str]):
+        if collection_design is not None:
+            for design in collection_design:
+                if design not in COLLECTION_DESIGN:
+                    raise ValueError(f"{design} is not a valid code for collection design")
+        self._collection_design = collection_design
+
+    @property
+    def use_and_access_conditions(self) -> list[str]:
+        return self._use_and_access_conditions
+
+    @use_and_access_conditions.setter
+    def use_and_access_conditions(self, use_and_access_conditions: list[str]):
+        if use_and_access_conditions is not None:
+            for condition in use_and_access_conditions:
+                if condition not in COLLECTION_USE_AND_ACCESS_CONDITIONS:
+                    raise ValueError(f"{condition} is not a valid code for use and access conditions")
+        self._use_and_access_conditions = use_and_access_conditions
+
+    @property
+    def publications(self) -> list[str]:
+        return self._publications
+
+    @publications.setter
+    def publications(self, publications: list[str]):
+        if publications is not None:
+            if not isinstance(publications, list):
+                raise TypeError("Publications must be a list.")
+            for publication in publications:
+                if not isinstance(publication, str):
+                    raise TypeError("Publications must be a list of strings.")
+        self._publications = publications
+
+    @classmethod
+    def from_json(cls, collection_json: dict, managing_biobank_id) -> Self:
+        """
+        Parse a JSON object into a MoFCollection object.
+        :param collection_json: json object representing the collection.
+        :param managing_biobank_id: id of managing biobank usually given by the institution (not a FHIR id!)
+        :return: MoFCollection object
+        """
+        try:
+            identifier = collection_json["identifier"][0]["value"]
+            name = collection_json["name"]
+            url = None
+            contact_name = None
+            contact_surname = None
+            contact_email = None
+            dataset_type = None
+            sample_source = None
+            sample_collection_setting = None
+            collection_design = None
+            use_and_access_conditions = None
+            publications = None
+            description = None
+            alias = collection_json.get("alias")[0]
+            if collection_json.get("telecom") is not None:
+                url = collection_json["telecom"][0]["value"]
+
+            if collection_json.get("contact") is not None:
+                contact_name = collection_json["contact"][0]["name"]["given"][0]
+                contact_surname = collection_json["contact"][0]["name"]["family"]
+                contact_email = collection_json["contact"][0]["telecom"][0]["value"]
+            extension = collection_json.get("extension", [])
+            for ext in extension:
+                match ext["url"].replace(f"{DEFINITION_BASE_URL}/StructureDefinition/", "", 1):
+                    case "dataset-type-extension":
+                        dataset_type = ext["valueCodeableConcept"]["coding"][0]["code"]
+                    case "sample-source-extension":
+                        sample_source = ext["valueCodeableConcept"]["coding"][0]["code"]
+                    case "sample-collection-setting-extension":
+                        sample_collection_setting = ext["valueCodeableConcept"]["coding"][0]["code"]
+                    case "collection-design-extension":
+                        if collection_design is None:
+                            collection_design = []
+                        collection_design.append(ext["valueCodeableConcept"]["coding"][0]["code"])
+                    case "use-and-access-conditions-extension":
+                        if use_and_access_conditions is None:
+                            use_and_access_conditions = []
+                        use_and_access_conditions.append(ext["valueCodeableConcept"]["coding"][0]["code"])
+                    case "publication-extension":
+                        if publications is None:
+                            publications = []
+                        publications.append(ext["valueString"])
+                    case "description-extension":
+                        description = ext["valueString"]
+                    case _:
+                        pass
+            return cls(identifier, name, managing_biobank_id, contact_name, contact_surname, contact_email, alias, url,
+                       description,
+                       dataset_type, sample_source,
+                       sample_collection_setting, collection_design, use_and_access_conditions)
+        except KeyError:
+            raise IncorrectJsonFormatException("Error occured when parsing json into MoFCollection")
+
+    def to_fhir(self, managing_organization_fhir_id: str) -> Organization:
+        """Return collection representation in FHIR
+        :param managing_organization_fhir_id: FHIR Identifier of the managing organization"""
+        fhir_org = Organization()
+        fhir_org.meta = Meta()
+        fhir_org.meta.profile = [DEFINITION_BASE_URL + "/StructureDefinition/Collection"]
+        fhir_org.identifier = [self.__create_fhir_identifier()]
+        fhir_org.type = [self.__create_codeable_concept(DEFINITION_BASE_URL + "/organizationTypeCS", "Collection")]
+        fhir_org.active = True
+        fhir_org.name = self.name
+        if self.alias is not None:
+            fhir_org.alias = [self.alias]
+        if self.url is not None:
+            fhir_org.telecom = [self.create_url(self.url)]
+        if self.contact_name or self.contact_surname or self.contact_email:
+            fhir_org.contact = [self.__create_contact()]
+        fhir_org.partOf = self.__create_managing_entity_reference(managing_organization_fhir_id)
+        extensions = []
+        if self.dataset_type is not None:
+            extensions.append(self.__create_codeable_concept_extension(
+                DEFINITION_BASE_URL + "/StructureDefinition/dataset-type-extension",
+                DEFINITION_BASE_URL + "/datasetTypeCS",
+                self.dataset_type))
+        if self.sample_source is not None:
+            extensions.append(self.__create_codeable_concept_extension(
+                DEFINITION_BASE_URL + "/StructureDefinition/sample-source-extension",
+                DEFINITION_BASE_URL + "/sampleSourceCS",
+                self.sample_source))
+        if self.sample_collection_setting is not None:
+            extensions.append(self.__create_codeable_concept_extension(
+                DEFINITION_BASE_URL + "/StructureDefinition/sample-collection-setting-extension",
+                DEFINITION_BASE_URL + "/sampleCollectionSettingCS", self.sample_collection_setting))
+        if self.collection_design is not None:
+            for design in self.collection_design:
+                extensions.append(self.__create_codeable_concept_extension(
+                    DEFINITION_BASE_URL + "/StructureDefinition/collection-design-extension",
+                    DEFINITION_BASE_URL + "/collectionDesignCS", design))
+        if self.use_and_access_conditions is not None:
+            for condition in self.use_and_access_conditions:
+                extensions.append(self.__create_codeable_concept_extension(
+                    DEFINITION_BASE_URL + "/StructureDefinition/use-and-access-conditions-extension",
+                    DEFINITION_BASE_URL + "/useAndAccessConditionsCS", condition))
+        if self.publications is not None:
+            for publication in self.publications:
+                extensions.append(self.__create_string_extension(
+                    DEFINITION_BASE_URL + "/StructureDefinition/publication-extension", publication))
+        if self.description is not None:
+            extensions.append(self.__create_string_extension(
+                DEFINITION_BASE_URL + "/StructureDefinition/description-extension", self.description))
+        if extensions:
+            fhir_org.extension = extensions
+        return fhir_org
+
+    def create_url(self, url: str) -> ContactPoint:
+        contact_point = ContactPoint()
+        contact_point.system = "url"
+        contact_point.value = url
+        return contact_point
+
+    def __create_contact(self) -> OrganizationContact:
+        contact = OrganizationContact()
+        contact.name = HumanName()
+        contact.name.given = [self.contact_name]
+        contact.name.family = self.contact_surname
+        contact.telecom = [ContactPoint()]
+        contact.telecom[0].system = "email"
+        contact.telecom[0].value = self.contact_email
+        contact.address = Address()
+        contact.address.country = self._country
+        return contact
+
+    @staticmethod
+    def __create_codeable_concept(url: str, code: str):
+        codeable_concept = CodeableConcept()
+        codeable_concept.coding = [Coding()]
+        codeable_concept.coding[0].code = code
+        codeable_concept.coding[0].system = url
+        return codeable_concept
+
+    @staticmethod
+    def __create_managing_entity_reference(managing_ogranization_fhir_id: str) -> FHIRReference:
+        entity_reference = FHIRReference()
+        entity_reference.reference = f"Organization/{managing_ogranization_fhir_id}"
+        return entity_reference
+
+    def __create_fhir_identifier(self) -> Identifier:
+        """Create fhir identifier."""
+        fhir_identifier = Identifier()
+        fhir_identifier.value = self._identifier
+        return fhir_identifier
+
+    @staticmethod
+    def __create_codeable_concept_extension(extension_url: str, codeable_concept_url: str,
+                                            value: str) -> Extension:
+        extension = Extension()
+        extension.url = extension_url
+        extension.valueCodeableConcept = CodeableConcept()
+        extension.valueCodeableConcept.coding = [Coding()]
+        extension.valueCodeableConcept.coding[0].code = value
+        extension.valueCodeableConcept.coding[0].system = codeable_concept_url
+        return extension
+
+    @staticmethod
+    def __create_integer_extension(extension_url, value) -> Extension:
+        extension = Extension()
+        extension.url = extension_url
+        extension.valueInteger = value
+        return extension
+
+    @staticmethod
+    def __create_string_extension(extension_url, value) -> Extension:
+        extension = Extension()
+        extension.url = extension_url
+        extension.valueString = value
+        return extension

--- a/MIABIS_on_FHIR/MoF_collection_organization.py
+++ b/MIABIS_on_FHIR/MoF_collection_organization.py
@@ -78,7 +78,6 @@ class MoFCollectionOrganization:
                 if not isinstance(publication, str):
                     raise TypeError("Publications must be a list of strings.")
 
-
         self._identifier: str = identifier
         self._name: str = name
         self._description: str = description
@@ -304,6 +303,7 @@ class MoFCollectionOrganization:
             contact_name = None
             contact_surname = None
             contact_email = None
+            country = None
             dataset_type = None
             sample_source = None
             sample_collection_setting = None
@@ -319,6 +319,7 @@ class MoFCollectionOrganization:
                 contact_name = collection_json["contact"][0]["name"]["given"][0]
                 contact_surname = collection_json["contact"][0]["name"]["family"]
                 contact_email = collection_json["contact"][0]["telecom"][0]["value"]
+                country = collection_json["contact"][0]["address"]["country"]
             extension = collection_json.get("extension", [])
             for ext in extension:
                 match ext["url"].replace(f"{DEFINITION_BASE_URL}/StructureDefinition/", "", 1):
@@ -344,10 +345,9 @@ class MoFCollectionOrganization:
                         description = ext["valueString"]
                     case _:
                         pass
-            return cls(identifier, name, managing_biobank_id, contact_name, contact_surname, contact_email, alias, url,
-                       description,
-                       dataset_type, sample_source,
-                       sample_collection_setting, collection_design, use_and_access_conditions)
+            return cls(identifier, name, managing_biobank_id, contact_name, contact_surname, contact_email, country,
+                       alias, url, description, dataset_type, sample_source, sample_collection_setting,
+                       collection_design, use_and_access_conditions, publications)
         except KeyError:
             raise IncorrectJsonFormatException("Error occured when parsing json into MoFCollection")
 

--- a/MIABIS_on_FHIR/MoF_network_organization.py
+++ b/MIABIS_on_FHIR/MoF_network_organization.py
@@ -1,0 +1,244 @@
+from typing import Self
+
+from fhirclient.models.address import Address
+from fhirclient.models.codeableconcept import CodeableConcept
+from fhirclient.models.coding import Coding
+from fhirclient.models.contactpoint import ContactPoint
+from fhirclient.models.extension import Extension
+from fhirclient.models.fhirreference import FHIRReference
+from fhirclient.models.humanname import HumanName
+from fhirclient.models.identifier import Identifier
+from fhirclient.models.meta import Meta
+from fhirclient.models.organization import Organization, OrganizationContact
+
+from MIABIS_on_FHIR.incorrect_json_format import IncorrectJsonFormatException
+from _constants import NETWORK_COMMON_COLLAB_TOPICS, DEFINITION_BASE_URL
+
+
+class MoFNetworkOrganization:
+    """Network Organization represent a formal part of a network member, like ist name, contact information, url, etc."""
+
+    def __init__(self, identifier: str, name: str, managing_biobank_id: str,
+                 contact_name: str = None, contact_surname: str = None, contact_email: str = None, country: str = None,
+                 common_collaboration_topics: list[str] = None, juristic_person: str = None):
+        """
+        :param identifier: network organizational identifier
+        :param name: name of the network
+        :param managing_biobank_id: biobank which is managing this Network
+        ( for the purposes of having a contact person for this network)
+        :param common_collaboration_topics: Topics that the network partners collaborate on.
+        :param juristic_person: The legal entity that is responsible for the network.
+        """
+        if not isinstance(identifier, str):
+            raise TypeError("Identifier must be string")
+        if not isinstance(name, str):
+            raise TypeError("Name must be string")
+        if not isinstance(managing_biobank_id, str):
+            raise TypeError("Managing biobank id must be string")
+        if contact_name is not None and not isinstance(contact_name, str):
+            raise TypeError("Contact name must be string")
+        if contact_surname is not None and not isinstance(contact_surname, str):
+            raise TypeError("Contact surname must be string")
+        if contact_email is not None and not isinstance(contact_email, str):
+            raise TypeError("Contact email must be string")
+        if country is not None and not isinstance(country, str):
+            raise TypeError("Country must be string")
+        if juristic_person is not None and not isinstance(juristic_person, str):
+            raise TypeError("Juristic person must be string")
+        self._identifier = identifier
+        self._name = name
+        self._managing_biobank_id = managing_biobank_id
+        self._contact_name = contact_name
+        self._contact_surname = contact_surname
+        self._contact_email = contact_email
+        self._country = country
+        self._juristic_person = juristic_person
+        if common_collaboration_topics is not None:
+            if not isinstance(common_collaboration_topics, list):
+                raise TypeError("Common collaboration topics must be a list")
+            for topic in common_collaboration_topics:
+                if topic not in NETWORK_COMMON_COLLAB_TOPICS:
+                    raise ValueError(f"{topic} is not a valid code for common collaboration topics")
+        self._common_collaboration_topics = common_collaboration_topics
+
+    @property
+    def identifier(self) -> str:
+        return self._identifier
+
+    @identifier.setter
+    def identifier(self, identifier: str):
+        if not isinstance(identifier, str):
+            raise TypeError("Identifier must be string")
+        self._identifier = identifier
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @name.setter
+    def name(self, name: str):
+        if not isinstance(name, str):
+            raise TypeError("Name must be string")
+        self._name = name
+
+    @property
+    def contact_name(self) -> str:
+        return self._contact_name
+
+    @contact_name.setter
+    def contact_name(self, contact_name: str):
+        if not isinstance(contact_name, str):
+            raise TypeError("Contact name must be string")
+        self._contact_name = contact_name
+
+    @property
+    def contact_surname(self) -> str:
+        return self._contact_surname
+
+    @contact_surname.setter
+    def contact_surname(self, contact_surname: str):
+        if not isinstance(contact_surname, str):
+            raise TypeError("Contact surname must be string")
+        self._contact_surname = contact_surname
+
+    @property
+    def contact_email(self) -> str:
+        return self._contact_email
+
+    @contact_email.setter
+    def contact_email(self, contact_email: str):
+        if not isinstance(contact_email, str):
+            raise TypeError("Contact email must be string")
+        self._contact_email = contact_email
+
+    @property
+    def country(self) -> str:
+        return self._country
+
+    @country.setter
+    def country(self, country: str):
+        if not isinstance(country, str):
+            raise TypeError("Country must be string")
+        self._country = country
+
+    @property
+    def managing_biobank_id(self) -> str:
+        return self._managing_biobank_id
+
+    @managing_biobank_id.setter
+    def managing_biobank_id(self, managing_biobank_id: str):
+        if not isinstance(managing_biobank_id, str):
+            raise TypeError("Managing biobank id must be string")
+        self._managing_biobank_id = managing_biobank_id
+
+    @property
+    def common_collaboration_topics(self) -> list[str]:
+        return self._common_collaboration_topics
+
+    @common_collaboration_topics.setter
+    def common_collaboration_topics(self, common_collaboration_topics: list[str]):
+        if not isinstance(common_collaboration_topics, list):
+            raise TypeError("Common collaboration topics must be a list")
+        for topic in common_collaboration_topics:
+            if topic not in NETWORK_COMMON_COLLAB_TOPICS:
+                raise ValueError(f"{topic} is not a valid code for common collaboration")
+        self._common_collaboration_topics = common_collaboration_topics
+
+    @property
+    def juristic_person(self) -> str:
+        return self._juristic_person
+
+    @juristic_person.setter
+    def juristic_person(self, juristic_person: str):
+        if not isinstance(juristic_person, str):
+            raise TypeError("Juristic person must be string")
+        self._juristic_person = juristic_person
+
+    @classmethod
+    def from_json(cls, network_json: dict, managing_biobank_id: str) -> Self:
+        try:
+            identifier = network_json["identifier"][0]["value"]
+            name = network_json["name"]
+            common_collaboration_topics = None
+            juristic_person = None
+            contact_name = None
+            contact_surname = None
+            contact_email = None
+            country = None
+            for contact in network_json.get("contact", []):
+                contact_name = contact["name"]["given"][0]
+                contact_surname = contact["name"]["family"]
+                contact_email = contact["telecom"][0]["value"]
+                country = contact["address"]["country"]
+            if "extension" in network_json:
+                common_collaboration_topics = []
+                for extension in network_json["extension"]:
+                    match extension["url"].replace(f"{DEFINITION_BASE_URL}/StructureDefinition/", "", 1):
+                        case "common-collaboration-topics":
+                            common_collaboration_topics.append(extension["valueCodeableConcept"]["coding"][0]["code"])
+                        case "juristic-person":
+                            juristic_person = extension["valueString"]
+            return cls(identifier, name, managing_biobank_id, contact_name, contact_surname, contact_email, country,
+                       common_collaboration_topics, juristic_person)
+        except KeyError:
+            raise IncorrectJsonFormatException("Error occured when parsing json into the MoFNetwork")
+
+    def to_fhir(self, managing_biobank_fhir_id: str) -> Organization:
+        network = Organization()
+        network.meta = Meta()
+        network.meta.profile = [DEFINITION_BASE_URL + "/StructureDefinition/Network"]
+        network.identifier = [self.__create_identifier()]
+        network.name = self._name
+        network.active = True
+        network.partOf = FHIRReference()
+        network.partOf.reference = f"Organization/{managing_biobank_fhir_id}"
+        network.contact = [self.__create_contact()]
+        extensions = []
+        if self._common_collaboration_topics is not None:
+            for topic in self._common_collaboration_topics:
+                extensions.append(
+                    self.__create_codaeble_concept_extension(
+                        DEFINITION_BASE_URL + "/StructureDefinition/common-collaboration-topics",
+                        DEFINITION_BASE_URL + "/common-collaboration-topics-vs",
+                        topic))
+        if self._juristic_person is not None:
+            extensions.append(
+                self.__create_string_extension(DEFINITION_BASE_URL + "/StructureDefinition/juristic-person",
+                                               self._juristic_person))
+        network.extension = extensions
+        return network
+
+    def __create_contact(self):
+        contact = OrganizationContact()
+        contact.name = HumanName()
+        contact.name.given = [self._contact_name]
+        contact.name.family = self._contact_surname
+        contact.telecom = [ContactPoint()]
+        contact.telecom[0].system = "email"
+        contact.telecom[0].value = self._contact_email
+        contact.address = Address()
+        contact.address.country = self._country
+        return contact
+
+    def __create_identifier(self):
+        identifier = Identifier()
+        identifier.system = DEFINITION_BASE_URL + "/network"
+        identifier.value = self._identifier
+        return identifier
+
+    @staticmethod
+    def __create_string_extension(url: str, value: str):
+        extension = Extension()
+        extension.url = url
+        extension.valueString = value
+        return extension
+
+    @staticmethod
+    def __create_codaeble_concept_extension(extension_url: str, codeable_concept_url: str, value: str, ):
+        extension = Extension()
+        extension.url = extension_url
+        extension.valueCodeableConcept = CodeableConcept()
+        extension.valueCodeableConcept.coding = [Coding()]
+        extension.valueCodeableConcept.coding[0].code = value
+        extension.valueCodeableConcept.coding[0].system = DEFINITION_BASE_URL + "/common-collaboration-topics-vs"
+        return extension

--- a/test/unit/model/test_biobank.py
+++ b/test/unit/model/test_biobank.py
@@ -94,6 +94,16 @@ class TestBiobank(unittest.TestCase):
             biobank = MoFBiobank("biobankId", "biobankName", "biobankAlias", "CZ", "ContactName", "ContactSurname",
                                  "email", bioprocessing_and_analysis_capabilities=["Genomics", "Invalid"])
 
+    def test_biobank_juristic_person(self):
+        biobank = MoFBiobank("biobankId", "biobankName", "biobankAlias", "CZ", "ContactName", "ContactSurname",
+                             "email", juristic_person="JuristicPerson")
+        self.assertEqual("JuristicPerson", biobank.juristic_person)
+
+    def test_biobank_juristic_person_invalid(self):
+        with self.assertRaises(TypeError):
+            bio = MoFBiobank("biobankId", "biobankName", "biobankAlias", "CZ", "ContactName", "ContactSurname",
+                             "email",juristic_person=47)
+
     def test_biobank_to_fhir_no_optional_args(self):
         biobank = MoFBiobank("biobankId", "biobankName", "biobankAlias", "CZ", "ContactName", "ContactSurname",
                              "email")

--- a/test/unit/model/test_collection.py
+++ b/test/unit/model/test_collection.py
@@ -8,55 +8,49 @@ from MIABIS_on_FHIR.storage_temperature import MoFStorageTemperature
 
 
 class TestCollection(unittest.TestCase):
-    collection_json = {'meta': {'versionId': '2', 'lastUpdated': '2024-07-31T08:30:29.773Z',
-                                'profile': ['http://example.com/StructureDefinition/Collection']},
-                       'name': 'collectionName', 'type': 'person', 'resourceType': 'Group', 'characteristic': [
-            {'exclude': False, 'code': {'coding': [{'system': 'http://example.com/characteristicCS', 'code': 'Age'}]},
-             'valueRange': {'high': {'value': 0}, 'low': {'value': 0}}},
-            {'exclude': False, 'code': {'coding': [{'system': 'http://example.com/characteristicCS', 'code': 'Sex'}]},
-             'valueCodeableConcept': {'coding': [{'system': 'http://example.com/sexCS', 'code': 'male'}]}},
-            {'exclude': False,
-             'code': {'coding': [{'system': 'http://example.com/characteristicCS', 'code': 'StorageTemperature'}]},
-             'valueCodeableConcept': {
-                 'coding': [{'system': 'http://example.com/storageTemperatureCS', 'code': 'temperatureLN'}]}},
-            {'exclude': False,
-             'code': {'coding': [{'system': 'http://example.com/characteristicCS', 'code': 'MaterialType'}]},
-             'valueCodeableConcept': {'coding': [{'system': 'http://example.com/materialTypeCS', 'code': 'DNA'}]}},
-            {'exclude': False,
-             'code': {'coding': [{'system': 'http://example.com/characteristicCS', 'code': 'Diagnosis'}]},
-             'valueCodeableConcept': {'coding': [{'system': 'http://hl7.org/fhir/sid/icd-10', 'code': 'C51'}]}}],
-                       'extension': [{'url': 'http://example.com/StructureDefinition/dataset-type-extension',
-                                      'valueCodeableConcept': {
-                                          'coding': [{'system': 'http://example.com/datasetTypeCS', 'code': 'Other'}]}},
-                                     {'url': 'http://example.com/StructureDefinition/sample-source-extension',
-                                      'valueCodeableConcept': {'coding': [
-                                          {'system': 'http://example.com/sampleSourceCS', 'code': 'Human'}]}}, {
-                                         'url': 'http://example.com/StructureDefinition/sample-collection-setting-extension',
-                                         'valueCodeableConcept': {'coding': [
-                                             {'system': 'http://example.com/sampleCollectionSettingCS',
-                                              'code': 'Other'}]}},
-                                     {'url': 'http://example.com/StructureDefinition/collection-design-extension',
-                                      'valueCodeableConcept': {'coding': [
-                                          {'system': 'http://example.com/collectionDesignCS', 'code': 'Other'}]}}, {
-                                         'url': 'http://example.com/StructureDefinition/use-and-access-conditions-extension',
-                                         'valueCodeableConcept': {'coding': [
-                                             {'system': 'http://example.com/useAndAccessConditionsCS',
-                                              'code': 'CommercialUse'}]}},
-                                     {'url': 'http://example.com/StructureDefinition/number-of-subjects-extension',
-                                      'valueInteger': 10},
-                                     {'url': 'http://example.com/StructureDefinition/inclusion-criteria-extension',
-                                      'valueCodeableConcept': {'coding': [
-                                          {'system': 'http://example.com/inclusionCriteriaCS', 'code': 'Sex'}]}}],
-                       'active': True, 'id': 'DEIH5GBYJPLZ7ZTE', 'identifier': [{'value': 'collectionId'}],
-                       'managingEntity': {'reference': 'Organization/DEIH5EK4B3PKQZYR'}, 'actual': True}
+    collection_json = {'meta': {'profile': ['http://example.com/StructureDefinition/Collection']}, 'extension': [
+        {'url': 'http://example.com/StructureDefinition/number-of-subjects-extension', 'valueInteger': 10},
+        {'url': 'http://example.com/StructureDefinition/inclusion-criteria-extension', 'valueCodeableConcept': {
+            'coding': [{'code': 'HealthStatus', 'system': 'http://example.com/inclusionCriteriaCS'}]}},
+        {'url': 'http://hl7.org/fhir/5.0/StructureDefinition/extension-Group.member.entity',
+         'valueReference': {'reference': 'Specimen/sampleFhirId1'}},
+        {'url': 'http://hl7.org/fhir/5.0/StructureDefinition/extension-Group.member.entity',
+         'valueReference': {'reference': 'Specimen/sampleFhirId2'}}], 'active': True, 'actual': True,
+                       'characteristic': [
+                           {'code': {'coding': [{'code': 'Age', 'system': 'http://example.com/characteristicCS'}]},
+                            'exclude': False, 'valueRange': {'high': {'value': 100}, 'low': {'value': 0}}},
+                           {'code': {'coding': [{'code': 'Sex', 'system': 'http://example.com/characteristicCS'}]},
+                            'exclude': False, 'valueCodeableConcept': {
+                               'coding': [{'code': 'male', 'system': 'http://example.com/sexCS'}]}}, {'code': {
+                               'coding': [
+                                   {'code': 'StorageTemperature', 'system': 'http://example.com/characteristicCS'}]},
+                               'exclude': False,
+                               'valueCodeableConcept': {
+                                   'coding': [{
+                                       'code': 'temperatureGN',
+                                       'system': 'http://example.com/storageTemperatureCS'}]}},
+                           {'code': {
+                               'coding': [{'code': 'MaterialType', 'system': 'http://example.com/characteristicCS'}]},
+                               'exclude': False, 'valueCodeableConcept': {
+                               'coding': [{'code': 'DNA', 'system': 'http://example.com/materialTypeCS'}]}}, {'code': {
+                               'coding': [{'code': 'Diagnosis', 'system': 'http://example.com/characteristicCS'}]},
+                               'exclude': False,
+                               'valueCodeableConcept': {
+                                   'coding': [
+                                       {
+                                           'code': 'C51',
+                                           'system': 'http://hl7.org/fhir/sid/icd-10'}]}}],
+                       'identifier': [{'value': 'collectionId'}],
+                       'managingEntity': {'reference': 'Organization/biobankFhirId'}, 'name': 'collectionName',
+                       'type': 'person', 'resourceType': 'Group'}
 
     def test_collection_init(self):
-        collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0, 100,
+        collection = MoFCollection("collectionId", "collectionName", "collectionOrgId", 0, 100,
                                    [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"])
         self.assertIsInstance(collection, MoFCollection)
         self.assertEqual("collectionId", collection.identifier)
         self.assertEqual("collectionName", collection.name)
-        self.assertEqual("managingBiobankId", collection.managing_biobank_id)
+        self.assertEqual("collectionOrgId", collection.managing_collection_org_id)
         self.assertEqual(0, collection.age_range_low)
         self.assertEqual(100, collection.age_range_high)
         self.assertEqual([MoFGender.MALE], collection.genders)
@@ -137,7 +131,7 @@ class TestCollection(unittest.TestCase):
         collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0, 100,
                                    [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"])
         with self.assertRaises(TypeError):
-            collection.managing_biobank_id = 37
+            collection.managing_collection_org_id = 37
 
     def test_collection_set_age_range_low_ok(self):
         collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0, 100,
@@ -199,11 +193,11 @@ class TestCollection(unittest.TestCase):
         with self.assertRaises(ValueError):
             collection.material_types = [37]
 
-    def test_collection_optional_args_description(self):
-        collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0, 100,
-                                   [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
-                                   description="description")
-        self.assertEqual("description", collection.description)
+    # def test_collection_optional_args_description(self):
+    #     collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0, 100,
+    #                                [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
+    #                                description="description")
+    #     self.assertEqual("description", collection.description)
 
     def test_collection_optional_args_description_invalid(self):
         with self.assertRaises(TypeError):
@@ -224,70 +218,70 @@ class TestCollection(unittest.TestCase):
                                        [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
                                        diagnoses=["C11111"])
 
-    def test_collection_optional_args_dataset_type(self):
-        collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0, 100,
-                                   [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
-                                   dataset_type="Genomic")
-        self.assertEqual("Genomic", collection.dataset_type)
+    # def test_collection_optional_args_dataset_type(self):
+    #     collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0, 100,
+    #                                [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
+    #                                dataset_type="Genomic")
+    #     self.assertEqual("Genomic", collection.dataset_type)
 
-    def test_collection_optional_args_dataset_type_invalid(self):
-        with self.assertRaises(ValueError):
-            collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0,
-                                       100,
-                                       [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
-                                       dataset_type="Invalid")
+    # def test_collection_optional_args_dataset_type_invalid(self):
+    #     with self.assertRaises(ValueError):
+    #         collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0,
+    #                                    100,
+    #                                    [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
+    #                                    dataset_type="Invalid")
 
-    def test_collection_optional_args_sample_source(self):
-        collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0, 100,
-                                   [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
-                                   sample_source="Human")
-        self.assertEqual("Human", collection.sample_source)
+    # def test_collection_optional_args_sample_source(self):
+    #     collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0, 100,
+    #                                [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
+    #                                sample_source="Human")
+    #     self.assertEqual("Human", collection.sample_source)
 
-    def test_collection_optional_args_sample_source_invalid(self):
-        with self.assertRaises(ValueError):
-            collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0,
-                                       100,
-                                       [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
-                                       sample_source="Invalid")
+    # def test_collection_optional_args_sample_source_invalid(self):
+    #     with self.assertRaises(ValueError):
+    #         collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0,
+    #                                    100,
+    #                                    [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
+    #                                    sample_source="Invalid")
+    #
+    # def test_collection_optional_args_sample_collection_setting(self):
+    #     collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0, 100,
+    #                                [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
+    #                                sample_collection_setting="Environment")
+    #     self.assertEqual("Environment", collection.sample_collection_setting)
+    #
+    # def test_collection_optional_args_sample_collection_setting_invalid(self):
+    #     with self.assertRaises(ValueError):
+    #         collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0,
+    #                                    100,
+    #                                    [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
+    #                                    sample_collection_setting="Invalid")
 
-    def test_collection_optional_args_sample_collection_setting(self):
-        collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0, 100,
-                                   [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
-                                   sample_collection_setting="Environment")
-        self.assertEqual("Environment", collection.sample_collection_setting)
+    # def test_collection_optional_args_collection_design(self):
+    #     collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0, 100,
+    #                                [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
+    #                                collection_design=["CaseControl"])
+    #     self.assertEqual(["CaseControl"], collection.collection_design)
 
-    def test_collection_optional_args_sample_collection_setting_invalid(self):
-        with self.assertRaises(ValueError):
-            collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0,
-                                       100,
-                                       [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
-                                       sample_collection_setting="Invalid")
+    # def test_collection_optional_args_collection_design_invalid(self):
+    #     with self.assertRaises(ValueError):
+    #         collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0,
+    #                                    100,
+    #                                    [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
+    #                                    collection_design=["Invalid"])
 
-    def test_collection_optional_args_collection_design(self):
-        collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0, 100,
-                                   [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
-                                   collection_design=["CaseControl"])
-        self.assertEqual(["CaseControl"], collection.collection_design)
-
-    def test_collection_optional_args_collection_design_invalid(self):
-        with self.assertRaises(ValueError):
-            collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0,
-                                       100,
-                                       [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
-                                       collection_design=["Invalid"])
-
-    def test_collection_optional_args_use_and_access_conditions(self):
-        collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0, 100,
-                                   [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
-                                   use_and_access_conditions=["CommercialUse"])
-        self.assertEqual(["CommercialUse"], collection.use_and_access_conditions)
-
-    def test_collection_optional_args_use_and_access_conditions_invalid(self):
-        with self.assertRaises(ValueError):
-            collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0,
-                                       100,
-                                       [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
-                                       use_and_access_conditions=["Invalid"])
+    # def test_collection_optional_args_use_and_access_conditions(self):
+    #     collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0, 100,
+    #                                [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
+    #                                use_and_access_conditions=["CommercialUse"])
+    #     self.assertEqual(["CommercialUse"], collection.use_and_access_conditions)
+    #
+    # def test_collection_optional_args_use_and_access_conditions_invalid(self):
+    #     with self.assertRaises(ValueError):
+    #         collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0,
+    #                                    100,
+    #                                    [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
+    #                                    use_and_access_conditions=["Invalid"])
 
     def test_collection_optional_args_inclusion_criteria(self):
         collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0, 100,
@@ -318,7 +312,7 @@ class TestCollection(unittest.TestCase):
     def test_collection_required_args_to_fhir(self):
         collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0, 100,
                                    [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"])
-        collection_fhir = collection.to_fhir("biobankFhirId")
+        collection_fhir = collection.to_fhir("biobankFhirId", ["sampleFhirId1", "sampleFhirId2"])
         self.assertIsInstance(collection_fhir, Group)
         self.assertEqual(collection.identifier, collection_fhir.identifier[0].value)
         self.assertEqual(collection.name, collection_fhir.name)
@@ -331,16 +325,15 @@ class TestCollection(unittest.TestCase):
                          collection_fhir.characteristic[2].valueCodeableConcept.coding[0].code)
         self.assertEqual(collection.material_types[0],
                          collection_fhir.characteristic[3].valueCodeableConcept.coding[0].code)
+        self.assertEqual(collection_fhir.extension[0].valueReference.reference, "Specimen/sampleFhirId1")
+        self.assertEqual(collection_fhir.extension[1].valueReference.reference, "Specimen/sampleFhirId2")
 
     def test_collection_optional_args_to_fhir(self):
         collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0, 100,
-                                   [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
-                                   description="description", diagnoses=["C51"], dataset_type="Genomic",
-                                   sample_source="Human", sample_collection_setting="Environment",
-                                   collection_design=["CaseControl"], use_and_access_conditions=["CommercialUse"],
+                                   [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"], diagnoses=["C51"],
                                    inclusion_criteria=["HealthStatus"], number_of_subjects=10,
-                                   publications=["publication"])
-        collection_fhir = collection.to_fhir("biobankFhirId")
+                                   )
+        collection_fhir = collection.to_fhir("biobankFhirId", ["sampleFhirId1", "sampleFhirId2"])
         self.assertIsInstance(collection_fhir, Group)
         self.assertEqual(collection.identifier, collection_fhir.identifier[0].value)
         self.assertEqual(collection.name, collection_fhir.name)
@@ -354,35 +347,24 @@ class TestCollection(unittest.TestCase):
         self.assertEqual(collection.material_types[0],
                          collection_fhir.characteristic[3].valueCodeableConcept.coding[0].code)
         self.assertEqual(collection.diagnoses[0], collection_fhir.characteristic[4].valueCodeableConcept.coding[0].code)
-        self.assertEqual(collection.dataset_type, collection_fhir.extension[0].valueCodeableConcept.coding[0].code)
-        self.assertEqual(collection.sample_source, collection_fhir.extension[1].valueCodeableConcept.coding[0].code)
-        self.assertEqual(collection.sample_collection_setting,
-                         collection_fhir.extension[2].valueCodeableConcept.coding[0].code)
-        self.assertEqual(collection.collection_design[0],
-                         collection_fhir.extension[3].valueCodeableConcept.coding[0].code)
-        self.assertEqual(collection.use_and_access_conditions[0],
-                         collection_fhir.extension[4].valueCodeableConcept.coding[0].code)
-        self.assertEqual(collection.number_of_subjects, collection_fhir.extension[5].valueInteger)
+        self.assertEqual(collection.number_of_subjects, collection_fhir.extension[0].valueInteger)
         self.assertEqual(collection.inclusion_criteria[0],
-                         collection_fhir.extension[6].valueCodeableConcept.coding[0].code)
-        self.assertEqual(collection.publications[0], collection_fhir.extension[7].valueString)
-        self.assertEqual(collection.description, collection_fhir.extension[8].valueString)
+                         collection_fhir.extension[1].valueCodeableConcept.coding[0].code)
+        self.assertEqual(collection_fhir.extension[2].valueReference.reference, "Specimen/sampleFhirId1")
+        self.assertEqual(collection_fhir.extension[3].valueReference.reference, "Specimen/sampleFhirId2")
 
     def test_collection_from_json(self):
-        collection = MoFCollection.from_json(self.collection_json, "biobankId")
+        collection = MoFCollection.from_json(self.collection_json, "biobankId", ["sampleId1"])
         self.assertIsInstance(collection, MoFCollection)
         self.assertEqual("collectionId", collection.identifier)
         self.assertEqual("collectionName", collection.name)
-        self.assertEqual("biobankId", collection.managing_biobank_id)
+        self.assertEqual("biobankId", collection.managing_collection_org_id)
         self.assertEqual(0, collection.age_range_low)
-        self.assertEqual(0, collection.age_range_high)
+        self.assertEqual(100, collection.age_range_high)
         self.assertEqual([MoFGender.MALE], collection.genders)
-        self.assertEqual([MoFStorageTemperature.TEMPERATURE_LN], collection.storage_temperatures)
+        self.assertEqual([MoFStorageTemperature.TEMPERATURE_GN], collection.storage_temperatures)
         self.assertEqual(["DNA"], collection.material_types)
         self.assertEqual(["C51"], collection.diagnoses)
-        self.assertEqual("Other", collection.dataset_type)
-        self.assertEqual("Human", collection.sample_source)
-        self.assertEqual("Other", collection.sample_collection_setting)
-        self.assertEqual(["Other"], collection.collection_design)
-        self.assertEqual(["CommercialUse"], collection.use_and_access_conditions)
+        self.assertEqual(["HealthStatus"], collection.inclusion_criteria)
         self.assertEqual(10, collection.number_of_subjects)
+        self.assertEqual(["sampleId1"], collection.sample_ids)

--- a/test/unit/model/test_collection.py
+++ b/test/unit/model/test_collection.py
@@ -192,13 +192,6 @@ class TestCollection(unittest.TestCase):
                                    [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"])
         with self.assertRaises(ValueError):
             collection.material_types = [37]
-
-    # def test_collection_optional_args_description(self):
-    #     collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0, 100,
-    #                                [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
-    #                                description="description")
-    #     self.assertEqual("description", collection.description)
-
     def test_collection_optional_args_description_invalid(self):
         with self.assertRaises(TypeError):
             collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0,
@@ -217,71 +210,6 @@ class TestCollection(unittest.TestCase):
                                        100,
                                        [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
                                        diagnoses=["C11111"])
-
-    # def test_collection_optional_args_dataset_type(self):
-    #     collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0, 100,
-    #                                [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
-    #                                dataset_type="Genomic")
-    #     self.assertEqual("Genomic", collection.dataset_type)
-
-    # def test_collection_optional_args_dataset_type_invalid(self):
-    #     with self.assertRaises(ValueError):
-    #         collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0,
-    #                                    100,
-    #                                    [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
-    #                                    dataset_type="Invalid")
-
-    # def test_collection_optional_args_sample_source(self):
-    #     collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0, 100,
-    #                                [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
-    #                                sample_source="Human")
-    #     self.assertEqual("Human", collection.sample_source)
-
-    # def test_collection_optional_args_sample_source_invalid(self):
-    #     with self.assertRaises(ValueError):
-    #         collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0,
-    #                                    100,
-    #                                    [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
-    #                                    sample_source="Invalid")
-    #
-    # def test_collection_optional_args_sample_collection_setting(self):
-    #     collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0, 100,
-    #                                [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
-    #                                sample_collection_setting="Environment")
-    #     self.assertEqual("Environment", collection.sample_collection_setting)
-    #
-    # def test_collection_optional_args_sample_collection_setting_invalid(self):
-    #     with self.assertRaises(ValueError):
-    #         collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0,
-    #                                    100,
-    #                                    [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
-    #                                    sample_collection_setting="Invalid")
-
-    # def test_collection_optional_args_collection_design(self):
-    #     collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0, 100,
-    #                                [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
-    #                                collection_design=["CaseControl"])
-    #     self.assertEqual(["CaseControl"], collection.collection_design)
-
-    # def test_collection_optional_args_collection_design_invalid(self):
-    #     with self.assertRaises(ValueError):
-    #         collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0,
-    #                                    100,
-    #                                    [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
-    #                                    collection_design=["Invalid"])
-
-    # def test_collection_optional_args_use_and_access_conditions(self):
-    #     collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0, 100,
-    #                                [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
-    #                                use_and_access_conditions=["CommercialUse"])
-    #     self.assertEqual(["CommercialUse"], collection.use_and_access_conditions)
-    #
-    # def test_collection_optional_args_use_and_access_conditions_invalid(self):
-    #     with self.assertRaises(ValueError):
-    #         collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0,
-    #                                    100,
-    #                                    [MoFGender.MALE], [MoFStorageTemperature.TEMPERATURE_GN], ["DNA"],
-    #                                    use_and_access_conditions=["Invalid"])
 
     def test_collection_optional_args_inclusion_criteria(self):
         collection = MoFCollection("collectionId", "collectionName", "managingBiobankId", 0, 100,

--- a/test/unit/model/test_collection_org.py
+++ b/test/unit/model/test_collection_org.py
@@ -4,6 +4,30 @@ from MIABIS_on_FHIR.MoF_collection_organization import MoFCollectionOrganization
 
 
 class TestCollectionOrganization(unittest.TestCase):
+    coll_org_json = {'meta': {'versionId': '7', 'lastUpdated': '2024-09-16T07:19:31.673Z',
+                              'profile': ['http://example.com/StructureDefinition/Collection']},
+                     'name': 'collectionName',
+                     'type': [{'coding': [{'system': 'http://example.com/organizationTypeCS', 'code': 'Collection'}]}],
+                     'resourceType': 'Organization', 'extension': [
+            {'url': 'http://example.com/StructureDefinition/dataset-type-extension',
+             'valueCodeableConcept': {'coding': [{'system': 'http://example.com/datasetTypeCS', 'code': 'Other'}]}},
+            {'url': 'http://example.com/StructureDefinition/sample-source-extension',
+             'valueCodeableConcept': {'coding': [{'system': 'http://example.com/sampleSourceCS', 'code': 'Human'}]}},
+            {'url': 'http://example.com/StructureDefinition/sample-collection-setting-extension',
+             'valueCodeableConcept': {
+                 'coding': [{'system': 'http://example.com/sampleCollectionSettingCS', 'code': 'Other'}]}},
+            {'url': 'http://example.com/StructureDefinition/collection-design-extension', 'valueCodeableConcept': {
+                'coding': [{'system': 'http://example.com/collectionDesignCS', 'code': 'Other'}]}},
+            {'url': 'http://example.com/StructureDefinition/use-and-access-conditions-extension',
+             'valueCodeableConcept': {
+                 'coding': [{'system': 'http://example.com/useAndAccessConditionsCS', 'code': 'CommercialUse'}]}},
+            {'url': 'http://example.com/StructureDefinition/publication-extension', 'valueString': 'publication'},
+            {'url': 'http://example.com/StructureDefinition/description-extension', 'valueString': 'description'}],
+                     'alias': ['collectionAlias'], 'active': True, 'id': 'DEPZWNXFPHMA5NLM',
+                     'identifier': [{'value': 'collectionId'}], 'telecom': [{'system': 'url', 'value': 'url'}],
+                     'partOf': {'reference': 'Organization/DEPZWNPN6CSOKEOC'}, 'contact': [
+            {'address': {'country': 'cz'}, 'name': {'family': 'Mrkva', 'given': ['Jozef']},
+             'telecom': [{'system': 'email', 'value': 'jozefmrkva@email.com'}]}]}
 
     def test_collection_org_init_required_params(self):
         collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
@@ -41,7 +65,6 @@ class TestCollectionOrganization(unittest.TestCase):
         self.assertEqual(["CommercialUse"], collection_org.use_and_access_conditions)
         self.assertEqual(["publication"], collection_org.publications)
 
-
     def test_collection_org_invalid_identifier_type_innit(self):
         with self.assertRaises(TypeError):
             collection_org = MoFCollectionOrganization(37, "collectionOrgName", "biobankId", "contactName",
@@ -64,62 +87,76 @@ class TestCollectionOrganization(unittest.TestCase):
 
     def test_collection_org_invalid_contact_surname_type_innit(self):
         with self.assertRaises(TypeError):
-            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
+                                                       "contactName",
                                                        22, "contactEmail", "cz")
 
     def test_collection_org_invalid_contact_email_type_innit(self):
         with self.assertRaises(TypeError):
-            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
+                                                       "contactName",
                                                        "contactSurname", 22, "cz")
 
     def test_collection_org_invalid_country_type_innit(self):
         with self.assertRaises(TypeError):
-            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
+                                                       "contactName",
                                                        "contactSurname", "contactEmail", 22)
 
     def test_collection_org_invalid_alias_type_innit(self):
         with self.assertRaises(TypeError):
-            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
+                                                       "contactName",
                                                        "contactSurname", "contactEmail", "cz", 22)
 
     def test_collection_org_invalid_url_type_innit(self):
         with self.assertRaises(TypeError):
-            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
+                                                       "contactName",
                                                        "contactSurname", "contactEmail", "cz", url=22)
 
     def test_collection_org_invalid_description_type_innit(self):
         with self.assertRaises(TypeError):
-            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
+                                                       "contactName",
                                                        "contactSurname", "contactEmail", "cz", description=22)
 
     def test_collection_org_invalid_dataset_type_type_innit(self):
         with self.assertRaises(ValueError):
-            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
+                                                       "contactName",
                                                        "contactSurname", "contactEmail", "cz", dataset_type=22)
 
     def test_collection_org_invalid_sample_source_type_innit(self):
         with self.assertRaises(ValueError):
-            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
+                                                       "contactName",
                                                        "contactSurname", "contactEmail", "cz", sample_source=22)
 
     def test_collection_org_invalid_sample_collection_setting_type_innit(self):
         with self.assertRaises(ValueError):
-            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
-                                                       "contactSurname", "contactEmail", "cz", sample_collection_setting=22)
+            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
+                                                       "contactName",
+                                                       "contactSurname", "contactEmail", "cz",
+                                                       sample_collection_setting=22)
 
     def test_collection_org_invalid_collection_design_type_innit(self):
         with self.assertRaises(TypeError):
-            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
+                                                       "contactName",
                                                        "contactSurname", "contactEmail", "cz", collection_design=22)
 
     def test_collection_org_invalid_use_and_access_conditions_type_innit(self):
         with self.assertRaises(TypeError):
-            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
-                                                       "contactSurname", "contactEmail", "cz", use_and_access_conditions=22)
+            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
+                                                       "contactName",
+                                                       "contactSurname", "contactEmail", "cz",
+                                                       use_and_access_conditions=22)
 
     def test_collection_org_invalid_publications_type_innit(self):
         with self.assertRaises(TypeError):
-            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
+                                                       "contactName",
                                                        "contactSurname", "contactEmail", "cz", publications=22)
 
     def test_collection_org_set_identifier_ok(self):
@@ -268,40 +305,45 @@ class TestCollectionOrganization(unittest.TestCase):
 
     def test_collection_org_set_sample_collection_setting_ok(self):
         collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
-                                                   "contactSurname", "contactEmail", "cz", sample_collection_setting="Environment")
+                                                   "contactSurname", "contactEmail", "cz",
+                                                   sample_collection_setting="Environment")
         collection_org.sample_collection_setting = "Unknown"
         self.assertEqual("Unknown", collection_org.sample_collection_setting)
 
     def test_collection_org_set_sample_collection_setting_invalid(self):
         collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
-                                                   "contactSurname", "contactEmail", "cz", sample_collection_setting="Environment")
+                                                   "contactSurname", "contactEmail", "cz",
+                                                   sample_collection_setting="Environment")
         with self.assertRaises(ValueError):
             collection_org.sample_collection_setting = "Invalid"
 
     def test_collection_org_set_collection_design_ok(self):
         collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
-                                                   "contactSurname", "contactEmail", "cz", collection_design=["CaseControl"])
+                                                   "contactSurname", "contactEmail", "cz",
+                                                   collection_design=["CaseControl"])
         collection_org.collection_design = ["CrossSectional"]
         self.assertEqual(["CrossSectional"], collection_org.collection_design)
 
     def test_collection_org_set_collection_design_invalid(self):
         collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
-                                                   "contactSurname", "contactEmail", "cz", collection_design=["CaseControl"])
+                                                   "contactSurname", "contactEmail", "cz",
+                                                   collection_design=["CaseControl"])
         with self.assertRaises(ValueError):
             collection_org.collection_design = ["Invalid"]
 
     def test_collection_org_set_use_and_access_conditions_ok(self):
         collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
-                                                   "contactSurname", "contactEmail", "cz", use_and_access_conditions=["CommercialUse"])
+                                                   "contactSurname", "contactEmail", "cz",
+                                                   use_and_access_conditions=["CommercialUse"])
         collection_org.use_and_access_conditions = ["Xenograft"]
         self.assertEqual(["Xenograft"], collection_org.use_and_access_conditions)
 
     def test_collection_org_set_use_and_access_conditions_invalid(self):
         collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
-                                                   "contactSurname", "contactEmail", "cz", use_and_access_conditions=["CommercialUse"])
+                                                   "contactSurname", "contactEmail", "cz",
+                                                   use_and_access_conditions=["CommercialUse"])
         with self.assertRaises(ValueError):
             collection_org.use_and_access_conditions = ["Invalid"]
-
 
     def test_collection_org_set_publications_ok(self):
         collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
@@ -346,9 +388,23 @@ class TestCollectionOrganization(unittest.TestCase):
         self.assertEqual("publication", collection_org_fhir.extension[5].valueString)
         self.assertEqual("description", collection_org_fhir.extension[6].valueString)
 
-
-
-
-
-
+    def test_collection_org_from_json(self):
+        collection_org = MoFCollectionOrganization.from_json(self.coll_org_json,"biobankId")
+        self.assertEqual("collectionId", collection_org.identifier)
+        self.assertEqual("collectionName", collection_org.name)
+        self.assertEqual("biobankId", collection_org.managing_biobank_id)
+        self.assertEqual("Jozef", collection_org.contact_name)
+        self.assertEqual("Mrkva", collection_org.contact_surname)
+        self.assertEqual("jozefmrkva@email.com", collection_org.contact_email)
+        self.assertEqual("cz", collection_org.country)
+        self.assertEqual("collectionAlias", collection_org.alias)
+        self.assertEqual("url", collection_org.url)
+        self.assertEqual("description", collection_org.description)
+        self.assertEqual("Other", collection_org.dataset_type)
+        self.assertEqual("Human", collection_org.sample_source)
+        self.assertEqual("Other", collection_org.sample_collection_setting)
+        self.assertEqual(["Other"], collection_org.collection_design)
+        self.assertEqual(["CommercialUse"], collection_org.use_and_access_conditions)
+        self.assertEqual(["publication"], collection_org.publications)
+        self.assertEqual("description", collection_org.description)
 

--- a/test/unit/model/test_collection_org.py
+++ b/test/unit/model/test_collection_org.py
@@ -1,0 +1,354 @@
+import unittest
+
+from MIABIS_on_FHIR.MoF_collection_organization import MoFCollectionOrganization
+
+
+class TestCollectionOrganization(unittest.TestCase):
+
+    def test_collection_org_init_required_params(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz")
+        self.assertIsInstance(collection_org, MoFCollectionOrganization)
+        self.assertEqual("collectionOrgId", collection_org.identifier)
+        self.assertEqual("collectionOrgName", collection_org.name)
+        self.assertEqual("biobankId", collection_org.managing_biobank_id)
+        self.assertEqual("contactName", collection_org.contact_name)
+        self.assertEqual("contactSurname", collection_org.contact_surname)
+        self.assertEqual("contactEmail", collection_org.contact_email)
+        self.assertEqual("cz", collection_org.country)
+
+    def test_collection_org_init_optional_params(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz", "alias", "url",
+                                                   "description",
+                                                   "LifeStyle", "Human", "Environment", ["CaseControl"],
+                                                   ["CommercialUse"], ["publication"])
+        self.assertIsInstance(collection_org, MoFCollectionOrganization)
+        self.assertEqual("collectionOrgId", collection_org.identifier)
+        self.assertEqual("collectionOrgName", collection_org.name)
+        self.assertEqual("biobankId", collection_org.managing_biobank_id)
+        self.assertEqual("contactName", collection_org.contact_name)
+        self.assertEqual("contactSurname", collection_org.contact_surname)
+        self.assertEqual("contactEmail", collection_org.contact_email)
+        self.assertEqual("cz", collection_org.country)
+        self.assertEqual("alias", collection_org.alias)
+        self.assertEqual("url", collection_org.url)
+        self.assertEqual("description", collection_org.description)
+        self.assertEqual("LifeStyle", collection_org.dataset_type)
+        self.assertEqual("Human", collection_org.sample_source)
+        self.assertEqual("Environment", collection_org.sample_collection_setting)
+        self.assertEqual(["CaseControl"], collection_org.collection_design)
+        self.assertEqual(["CommercialUse"], collection_org.use_and_access_conditions)
+        self.assertEqual(["publication"], collection_org.publications)
+
+
+    def test_collection_org_invalid_identifier_type_innit(self):
+        with self.assertRaises(TypeError):
+            collection_org = MoFCollectionOrganization(37, "collectionOrgName", "biobankId", "contactName",
+                                                       "contactSurname", "contactEmail", "cz")
+
+    def test_collection_org_invalid_name_type_innit(self):
+        with self.assertRaises(TypeError):
+            collection_org = MoFCollectionOrganization("collectionOrgId", 22, "biobankId", "contactName",
+                                                       "contactSurname", "contactEmail", "cz")
+
+    def test_collection_org_invalid_managing_biobank_id_type_innit(self):
+        with self.assertRaises(TypeError):
+            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", 22, "contactName",
+                                                       "contactSurname", "contactEmail", "cz")
+
+    def test_collection_org_invalid_contact_name_type_innit(self):
+        with self.assertRaises(TypeError):
+            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", 22,
+                                                       "contactSurname", "contactEmail", "cz")
+
+    def test_collection_org_invalid_contact_surname_type_innit(self):
+        with self.assertRaises(TypeError):
+            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                       22, "contactEmail", "cz")
+
+    def test_collection_org_invalid_contact_email_type_innit(self):
+        with self.assertRaises(TypeError):
+            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                       "contactSurname", 22, "cz")
+
+    def test_collection_org_invalid_country_type_innit(self):
+        with self.assertRaises(TypeError):
+            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                       "contactSurname", "contactEmail", 22)
+
+    def test_collection_org_invalid_alias_type_innit(self):
+        with self.assertRaises(TypeError):
+            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                       "contactSurname", "contactEmail", "cz", 22)
+
+    def test_collection_org_invalid_url_type_innit(self):
+        with self.assertRaises(TypeError):
+            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                       "contactSurname", "contactEmail", "cz", url=22)
+
+    def test_collection_org_invalid_description_type_innit(self):
+        with self.assertRaises(TypeError):
+            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                       "contactSurname", "contactEmail", "cz", description=22)
+
+    def test_collection_org_invalid_dataset_type_type_innit(self):
+        with self.assertRaises(ValueError):
+            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                       "contactSurname", "contactEmail", "cz", dataset_type=22)
+
+    def test_collection_org_invalid_sample_source_type_innit(self):
+        with self.assertRaises(ValueError):
+            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                       "contactSurname", "contactEmail", "cz", sample_source=22)
+
+    def test_collection_org_invalid_sample_collection_setting_type_innit(self):
+        with self.assertRaises(ValueError):
+            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                       "contactSurname", "contactEmail", "cz", sample_collection_setting=22)
+
+    def test_collection_org_invalid_collection_design_type_innit(self):
+        with self.assertRaises(TypeError):
+            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                       "contactSurname", "contactEmail", "cz", collection_design=22)
+
+    def test_collection_org_invalid_use_and_access_conditions_type_innit(self):
+        with self.assertRaises(TypeError):
+            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                       "contactSurname", "contactEmail", "cz", use_and_access_conditions=22)
+
+    def test_collection_org_invalid_publications_type_innit(self):
+        with self.assertRaises(TypeError):
+            collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                       "contactSurname", "contactEmail", "cz", publications=22)
+
+    def test_collection_org_set_identifier_ok(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz")
+        collection_org.identifier = "newId"
+        self.assertEqual("newId", collection_org.identifier)
+
+    def test_collection_org_set_identifier_invalid(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz")
+        with self.assertRaises(TypeError):
+            collection_org.identifier = 37
+
+    def test_collection_org_set_name_ok(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz")
+        collection_org.name = "newName"
+        self.assertEqual("newName", collection_org.name)
+
+    def test_collection_org_set_name_invalid(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz")
+        with self.assertRaises(TypeError):
+            collection_org.name = 37
+
+    def test_collection_org_set_managing_biobank_id_ok(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz")
+        collection_org.managing_biobank_id = "newId"
+        self.assertEqual("newId", collection_org.managing_biobank_id)
+
+    def test_collection_org_set_managing_biobank_id_invalid(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz")
+        with self.assertRaises(TypeError):
+            collection_org.managing_biobank_id = 37
+
+    def test_collection_org_set_contact_name_ok(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz")
+        collection_org.contact_name = "newName"
+        self.assertEqual("newName", collection_org.contact_name)
+
+    def test_collection_org_set_contact_name_invalid(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz")
+        with self.assertRaises(TypeError):
+            collection_org.contact_name = 37
+
+    def test_collection_org_set_contact_surname_ok(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz")
+        collection_org.contact_surname = "newName"
+        self.assertEqual("newName", collection_org.contact_surname)
+
+    def test_collection_org_set_contact_surname_invalid(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz")
+        with self.assertRaises(TypeError):
+            collection_org.contact_surname = 37
+
+    def test_collection_org_set_contact_email_ok(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz")
+        collection_org.contact_email = "newName"
+        self.assertEqual("newName", collection_org.contact_email)
+
+    def test_collection_org_set_contact_email_invalid(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz")
+        with self.assertRaises(TypeError):
+            collection_org.contact_email = 37
+
+    def test_collection_org_set_country_ok(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz")
+        collection_org.country = "newName"
+        self.assertEqual("newName", collection_org.country)
+
+    def test_collection_org_set_country_invalid(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz")
+        with self.assertRaises(TypeError):
+            collection_org.country = 37
+
+    def test_collection_org_set_alias_ok(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz", "alias")
+        collection_org.alias = "newName"
+        self.assertEqual("newName", collection_org.alias)
+
+    def test_collection_org_set_alias_invalid(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz", "alias")
+        with self.assertRaises(TypeError):
+            collection_org.alias = 37
+
+    def test_collection_org_set_url_ok(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz", url="url")
+        collection_org.url = "newName"
+        self.assertEqual("newName", collection_org.url)
+
+    def test_collection_org_set_url_invalid(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz", url="url")
+        with self.assertRaises(TypeError):
+            collection_org.url = 37
+
+    def test_collection_org_set_description_ok(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz", description="description")
+        collection_org.description = "newName"
+        self.assertEqual("newName", collection_org.description)
+
+    def test_collection_org_set_description_invalid(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz", description="description")
+        with self.assertRaises(TypeError):
+            collection_org.description = 37
+
+    def test_collection_org_set_dataset_type_ok(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz", dataset_type="LifeStyle")
+        collection_org.dataset_type = "Environmental"
+        self.assertEqual("Environmental", collection_org.dataset_type)
+
+    def test_collection_org_set_dataset_type_invalid(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz", dataset_type="LifeStyle")
+        with self.assertRaises(ValueError):
+            collection_org.dataset_type = 37
+
+    def test_collection_org_set_sample_source_ok(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz", sample_source="Human")
+        collection_org.sample_source = "Environment"
+        self.assertEqual("Environment", collection_org.sample_source)
+
+    def test_collection_org_set_sample_source_invalid(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz", sample_source="Human")
+        with self.assertRaises(ValueError):
+            collection_org.sample_source = "Invalid"
+
+    def test_collection_org_set_sample_collection_setting_ok(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz", sample_collection_setting="Environment")
+        collection_org.sample_collection_setting = "Unknown"
+        self.assertEqual("Unknown", collection_org.sample_collection_setting)
+
+    def test_collection_org_set_sample_collection_setting_invalid(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz", sample_collection_setting="Environment")
+        with self.assertRaises(ValueError):
+            collection_org.sample_collection_setting = "Invalid"
+
+    def test_collection_org_set_collection_design_ok(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz", collection_design=["CaseControl"])
+        collection_org.collection_design = ["CrossSectional"]
+        self.assertEqual(["CrossSectional"], collection_org.collection_design)
+
+    def test_collection_org_set_collection_design_invalid(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz", collection_design=["CaseControl"])
+        with self.assertRaises(ValueError):
+            collection_org.collection_design = ["Invalid"]
+
+    def test_collection_org_set_use_and_access_conditions_ok(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz", use_and_access_conditions=["CommercialUse"])
+        collection_org.use_and_access_conditions = ["Xenograft"]
+        self.assertEqual(["Xenograft"], collection_org.use_and_access_conditions)
+
+    def test_collection_org_set_use_and_access_conditions_invalid(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz", use_and_access_conditions=["CommercialUse"])
+        with self.assertRaises(ValueError):
+            collection_org.use_and_access_conditions = ["Invalid"]
+
+
+    def test_collection_org_set_publications_ok(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz", publications=["publication"])
+        collection_org.publications = ["publication2"]
+        self.assertEqual(["publication2"], collection_org.publications)
+
+    def test_collection_org_set_publications_invalid(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz", publications=["publication"])
+        with self.assertRaises(TypeError):
+            collection_org.publications = 37
+
+    def test_collection_org_to_fhir_required_params_ok(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz")
+        collection_org_fhir = collection_org.to_fhir("biobankFhirId")
+        self.assertEqual("collectionOrgId", collection_org_fhir.identifier[0].value)
+        self.assertEqual("collectionOrgName", collection_org_fhir.name)
+        self.assertEqual("Organization/biobankFhirId", collection_org_fhir.partOf.reference)
+        self.assertEqual("Organization", collection_org_fhir.resource_type)
+        self.assertEqual(True, collection_org_fhir.active)
+        self.assertEqual("contactName", collection_org_fhir.contact[0].name.given[0])
+        self.assertEqual("contactSurname", collection_org_fhir.contact[0].name.family)
+        self.assertEqual("contactEmail", collection_org_fhir.contact[0].telecom[0].value)
+        self.assertEqual("cz", collection_org_fhir.contact[0].address.country)
+
+    def test_collection_org_to_fhir_optional_params_ok(self):
+        collection_org = MoFCollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+                                                   "contactSurname", "contactEmail", "cz", "alias", "url",
+                                                   "description",
+                                                   "LifeStyle", "Human", "Environment", ["CaseControl"],
+                                                   ["CommercialUse"], ["publication"])
+        collection_org_fhir = collection_org.to_fhir("biobankFhirId")
+        self.assertEqual("alias", collection_org_fhir.alias[0])
+        self.assertEqual("url", collection_org_fhir.telecom[0].value)
+        self.assertEqual("LifeStyle", collection_org_fhir.extension[0].valueCodeableConcept.coding[0].code)
+        self.assertEqual("Human", collection_org_fhir.extension[1].valueCodeableConcept.coding[0].code)
+        self.assertEqual("Environment", collection_org_fhir.extension[2].valueCodeableConcept.coding[0].code)
+        self.assertEqual("CaseControl", collection_org_fhir.extension[3].valueCodeableConcept.coding[0].code)
+        self.assertEqual("CommercialUse", collection_org_fhir.extension[4].valueCodeableConcept.coding[0].code)
+        self.assertEqual("publication", collection_org_fhir.extension[5].valueString)
+        self.assertEqual("description", collection_org_fhir.extension[6].valueString)
+
+
+
+
+
+
+

--- a/test/unit/model/test_network.py
+++ b/test/unit/model/test_network.py
@@ -13,27 +13,29 @@ class TestNetwork(unittest.TestCase):
                     'identifier': [{'system': 'http://example.com/network', 'value': 'networkId'}], 'actual': True}
 
     def test_network_init(self):
-        network = MoFNetwork("networkId", "networkName", "biobankId", ["Charter"])
+        network = MoFNetwork("networkId", "networkName", "biobankId", ["collMemID1, collemMemID2"],
+                             ["bioMemID1, bioMemID2"])
         self.assertIsInstance(network, MoFNetwork)
         self.assertEqual("networkId", network.identifier)
         self.assertEqual("networkName", network.name)
-        self.assertEqual(["Charter"], network.common_collaboration_topics)
+        self.assertEqual(["collMemID1, collemMemID2"], network.members_collections_ids)
+        self.assertEqual(["bioMemID1, bioMemID2"], network.members_biobanks_ids)
 
     def test_network_invalid_identifier_type_innit(self):
         with self.assertRaises(TypeError):
-            network = MoFNetwork(37, "networkName", "biobankId", ["Charter"])
+            network = MoFNetwork(37, "networkName", "biobankId")
 
     def test_network_invalid_name_type_innit(self):
         with self.assertRaises(TypeError):
-            network = MoFNetwork("networkId", 22, "biobankId", ["Charter"])
+            network = MoFNetwork("networkId", 22, "biobankId")
 
-    def test_network_invalid_common_collaboration_topics_type_innit(self):
+    def test_network_members_collection_ids_invalid_type(self):
         with self.assertRaises(TypeError):
-            network = MoFNetwork("networkId", "networkName", "biobankId", 22)
+            network = MoFNetwork("networkId", "networkName", "biobankId", [5])
 
-    def test_network_common_collaboration_topics_invalid(self):
-        with self.assertRaises(ValueError):
-            network = MoFNetwork("networkId", "networkName", "biobankId", ["invalid"])
+    def test_network_members_biobanks_ids_invalid_type(self):
+        with self.assertRaises(TypeError):
+            network = MoFNetwork("networkId", "networkName", "biobankId", ["collid"], [5])
 
     def test_network_set_identifier_ok(self):
         network = MoFNetwork("networkId", "networkName", "biobankId", ["Charter"])
@@ -41,42 +43,45 @@ class TestNetwork(unittest.TestCase):
         self.assertEqual("newId", network.identifier)
 
     def test_network_set_identifier_invalid(self):
-        network = MoFNetwork("networkId", "networkName", "biobankId", ["Charter"])
+        network = MoFNetwork("networkId", "networkName", "biobankId", ["collid"])
         with self.assertRaises(TypeError):
             network.identifier = 37
 
     def test_network_set_name_ok(self):
-        network = MoFNetwork("networkId", "networkName", "biobankId", ["Charter"])
+        network = MoFNetwork("networkId", "networkName", "biobankId", ["collid"])
         network.name = "newName"
         self.assertEqual("newName", network.name)
 
     def test_network_set_name_invalid(self):
-        network = MoFNetwork("networkId", "networkName", "biobankId", ["Charter"])
+        network = MoFNetwork("networkId", "networkName", "biobankId", ["collid"])
         with self.assertRaises(TypeError):
             network.name = 37
 
-    def test_network_set_common_collaboration_topics_ok(self):
-        network = MoFNetwork("networkId", "networkName", "biobankId", ["Charter"])
+    def test_network_set_collection_ids_valid(self):
+        network = MoFNetwork("networkId", "networkName", "biobankId", ["cllid"])
         network.common_collaboration_topics = ["SOP"]
         self.assertEqual(["SOP"], network.common_collaboration_topics)
 
-    def test_network_set_common_collaboration_topics_invalid(self):
-        network = MoFNetwork("networkId", "networkName", "biobankId", ["Charter"])
-        with self.assertRaises(ValueError):
-            network.common_collaboration_topics = ["invalid"]
+    def test_network_set_collection_ids_invalid(self):
+        network = MoFNetwork("networkId", "networkName", "biobankId", ["collId"])
+        with self.assertRaises(TypeError):
+            network.members_collections_ids = [5]
 
     def test_network_to_fhir(self):
-        network = MoFNetwork("networkId", "networkName", "biobankId", ["Charter"])
-        network_fhir = network.to_fhir("biobankFhirId")
+        network = MoFNetwork("networkId", "networkName", "biobankId", ["collid"])
+        network_fhir = network.to_fhir("biobankFhirId",["collfhirid1", "collfhirid2"], ["biobankFhirId1", "biobankFhirId2"])
         self.assertTrue(network_fhir.active)
         self.assertEqual("person", network_fhir.type)
         self.assertEqual("networkName", network_fhir.name)
-        self.assertEqual("Charter", network_fhir.extension[0].valueCodeableConcept.coding[0].code)
         self.assertEqual("Organization/biobankFhirId", network_fhir.managingEntity.reference)
+        self.assertEqual("Group/collfhirid1", network_fhir.extension[0].valueReference.reference)
+        self.assertEqual("Group/collfhirid2", network_fhir.extension[1].valueReference.reference)
+        self.assertEqual("Organization/biobankFhirId1", network_fhir.extension[2].valueReference.reference)
+        self.assertEqual("Organization/biobankFhirId2", network_fhir.extension[3].valueReference.reference)
+
 
     def test_network_from_json(self):
         network = MoFNetwork.from_json(self.network_json, "biobankId")
         self.assertIsInstance(network, MoFNetwork)
         self.assertEqual("networkId", network.identifier)
         self.assertEqual("networkName", network.name)
-        self.assertEqual(["SOP"], network.common_collaboration_topics)

--- a/test/unit/model/test_network_org.py
+++ b/test/unit/model/test_network_org.py
@@ -1,0 +1,210 @@
+import unittest
+
+from MIABIS_on_FHIR.MoF_network_organization import MoFNetworkOrganization
+
+
+class TestNetworkOrganization(unittest.TestCase):
+    network_org_json = {'meta': {'profile': ['http://example.com/StructureDefinition/Network']}, 'extension': [
+        {'url': 'http://example.com/StructureDefinition/common-collaboration-topics', 'valueCodeableConcept': {
+            'coding': [{'code': 'Charter', 'system': 'http://example.com/common-collaboration-topics-vs'}]}},
+        {'url': 'http://example.com/StructureDefinition/juristic-person', 'valueString': 'juristicPerson'}],
+                        'active': True, 'contact': [
+            {'address': {'country': 'country'}, 'name': {'family': 'contactSurname', 'given': ['contactName']},
+             'telecom': [{'system': 'email', 'value': 'contactEmail'}]}],
+                        'identifier': [{'system': 'http://example.com/network', 'value': 'networkOrgId'}],
+                        'name': 'networkOrgName', 'partOf': {'reference': 'Organization/biobankFhirId'},
+                        'resourceType': 'Organization'}
+
+    def test_network_org_required_params_init(self):
+        network_org = MoFNetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        self.assertIsInstance(network_org, MoFNetworkOrganization)
+        self.assertEqual("networkOrgId", network_org.identifier)
+        self.assertEqual("networkOrgName", network_org.name)
+        self.assertEqual("biobankId", network_org.managing_biobank_id)
+
+    def test_network_org_optional_params_init(self):
+        network_org = MoFNetworkOrganization("networkOrgId", "networkOrgName", "biobankId", "contactName",
+                                             "contactSurname", "contactEmail", "country", ["Charter"], "juristicPerson")
+        self.assertIsInstance(network_org, MoFNetworkOrganization)
+        self.assertEqual("networkOrgId", network_org.identifier)
+        self.assertEqual("networkOrgName", network_org.name)
+        self.assertEqual("biobankId", network_org.managing_biobank_id)
+        self.assertEqual("contactName", network_org.contact_name)
+        self.assertEqual("contactSurname", network_org.contact_surname)
+        self.assertEqual("contactEmail", network_org.contact_email)
+        self.assertEqual("country", network_org.country)
+        self.assertEqual(["Charter"], network_org.common_collaboration_topics)
+        self.assertEqual("juristicPerson", network_org.juristic_person)
+
+    def test_network_org_invalid_identifier_type_innit(self):
+        with self.assertRaises(TypeError):
+            network_org = MoFNetworkOrganization(37, "networkOrgName", "biobankId")
+
+    def test_network_org_invalid_name_type_innit(self):
+        with self.assertRaises(TypeError):
+            network_org = MoFNetworkOrganization("networkOrgId", 22, "biobankId")
+
+    def test_network_org_invalid_managing_biobank_id_type_innit(self):
+        with self.assertRaises(TypeError):
+            network_org = MoFNetworkOrganization("networkOrgId", "networkOrgName", 22)
+
+    def test_network_org_invalid_contact_name_type_innit(self):
+        with self.assertRaises(TypeError):
+            network_org = MoFNetworkOrganization("networkOrgId", "networkOrgName", "biobankId", 22)
+
+    def test_network_org_invalid_contact_surname_type_innit(self):
+        with self.assertRaises(TypeError):
+            network_org = MoFNetworkOrganization("networkOrgId", "networkOrgName", "biobankId", "contactName", 22)
+
+    def test_network_org_invalid_contact_email_type_innit(self):
+        with self.assertRaises(TypeError):
+            network_org = MoFNetworkOrganization("networkOrgId", "networkOrgName", "biobankId", "contactName",
+                                                 "contactSurname", 22)
+
+    def test_network_org_invalid_country_type_innit(self):
+        with self.assertRaises(TypeError):
+            network_org = MoFNetworkOrganization("networkOrgId", "networkOrgName", "biobankId", "contactName",
+                                                 "contactSurname", "contactEmail", 22)
+
+    def test_network_org_invalid_common_collaboration_topics_type_innit(self):
+        with self.assertRaises(TypeError):
+            network_org = MoFNetworkOrganization("networkOrgId", "networkOrgName", "biobankId", "contactName",
+                                                 "contactSurname", "contactEmail", "country", 22)
+
+    def test_network_org_invalid_common_collaboration_topics_value_innit(self):
+        with self.assertRaises(ValueError):
+            network_org = MoFNetworkOrganization("networkOrgId", "networkOrgName", "biobankId", "contactName",
+                                                 "contactSurname", "contactEmail", "country", ["invalidTopic"])
+
+    def test_network_org_invalid_juristic_person_type_innit(self):
+        with self.assertRaises(TypeError):
+            network_org = MoFNetworkOrganization("networkOrgId", "networkOrgName", "biobankId", "contactName",
+                                                 "contactSurname", "contactEmail", "country", ["Charter"], 22)
+
+    def test_network_org_set_identifier_ok(self):
+        network_org = MoFNetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        network_org.identifier = "newId"
+        self.assertEqual("newId", network_org.identifier)
+
+    def test_network_org_set_identifier_invalid(self):
+        network_org = MoFNetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        with self.assertRaises(TypeError):
+            network_org.identifier = 37
+
+    def test_network_org_set_name_ok(self):
+        network_org = MoFNetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        network_org.name = "newName"
+        self.assertEqual("newName", network_org.name)
+
+    def test_network_org_set_name_invalid(self):
+        network_org = MoFNetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        with self.assertRaises(TypeError):
+            network_org.name = 37
+
+    def test_network_org_set_managing_biobank_id_ok(self):
+        network_org = MoFNetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        network_org.managing_biobank_id = "newId"
+        self.assertEqual("newId", network_org.managing_biobank_id)
+
+    def test_network_org_set_managing_biobank_id_invalid(self):
+        network_org = MoFNetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        with self.assertRaises(TypeError):
+            network_org.managing_biobank_id = 37
+
+    def test_network_org_set_contact_name_ok(self):
+        network_org = MoFNetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        network_org.contact_name = "newName"
+        self.assertEqual("newName", network_org.contact_name)
+
+    def test_network_org_set_contact_name_invalid(self):
+        network_org = MoFNetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        with self.assertRaises(TypeError):
+            network_org.contact_name = 37
+
+    def test_network_org_set_contact_surname_ok(self):
+        network_org = MoFNetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        network_org.contact_surname = "newName"
+        self.assertEqual("newName", network_org.contact_surname)
+
+    def test_network_org_set_contact_surname_invalid(self):
+        network_org = MoFNetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        with self.assertRaises(TypeError):
+            network_org.contact_surname = 37
+
+    def test_network_org_set_contact_email_ok(self):
+        network_org = MoFNetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        network_org.contact_email = "newName"
+        self.assertEqual("newName", network_org.contact_email)
+
+    def test_network_org_set_contact_email_invalid(self):
+        network_org = MoFNetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        with self.assertRaises(TypeError):
+            network_org.contact_email = 37
+
+    def test_network_org_set_country_ok(self):
+        network_org = MoFNetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        network_org.country = "newName"
+        self.assertEqual("newName", network_org.country)
+
+    def test_network_org_set_country_invalid(self):
+        network_org = MoFNetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        with self.assertRaises(TypeError):
+            network_org.country = 37
+
+    def test_network_org_set_common_collaboration_topics_valid(self):
+        network_org = MoFNetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        network_org.common_collaboration_topics = ["SOP"]
+        self.assertEqual(["SOP"], network_org.common_collaboration_topics)
+
+    def test_network_org_set_common_collaboration_topics_invalid(self):
+        network_org = MoFNetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        with self.assertRaises(TypeError):
+            network_org.common_collaboration_topics = 33
+
+    def test_network_org_set_common_collaboration_topics_invalid_value(self):
+        network_org = MoFNetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        with self.assertRaises(ValueError):
+            network_org.common_collaboration_topics = ["invalidTopic"]
+
+    def test_network_org_set_juristic_person_ok(self):
+        network_org = MoFNetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        network_org.juristic_person = "newName"
+        self.assertEqual("newName", network_org.juristic_person)
+
+    def test_network_org_set_juristic_person_invalid(self):
+        network_org = MoFNetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        with self.assertRaises(TypeError):
+            network_org.juristic_person = 37
+
+    def test_network_org_to_fhir(self):
+        network_org = MoFNetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        network_org_fhir = network_org.to_fhir("biobankFhirId")
+        self.assertEqual("networkOrgId", network_org_fhir.identifier[0].value)
+        self.assertEqual("networkOrgName", network_org_fhir.name)
+        self.assertEqual("Organization/biobankFhirId", network_org_fhir.partOf.reference)
+
+    def test_network_org_to_fhir_optional_params(self):
+        network_org = MoFNetworkOrganization("networkOrgId", "networkOrgName", "biobankId", "contactName",
+                                             "contactSurname", "contactEmail", "country", ["Charter"], "juristicPerson")
+        network_org_fhir = network_org.to_fhir("biobankFhirId")
+        self.assertEqual("networkOrgId", network_org_fhir.identifier[0].value)
+        self.assertEqual("networkOrgName", network_org_fhir.name)
+        self.assertEqual("Organization/biobankFhirId", network_org_fhir.partOf.reference)
+        self.assertEqual("contactName", network_org_fhir.contact[0].name.given[0])
+        self.assertEqual("contactSurname", network_org_fhir.contact[0].name.family)
+        self.assertEqual("contactEmail", network_org_fhir.contact[0].telecom[0].value)
+        self.assertEqual("country", network_org_fhir.contact[0].address.country)
+        self.assertEqual("Charter", network_org_fhir.extension[0].valueCodeableConcept.coding[0].code)
+        self.assertEqual("juristicPerson", network_org_fhir.extension[1].valueString)
+
+    def test_network_org_from_json(self):
+        network_org = MoFNetworkOrganization.from_json(self.network_org_json, "biobankId")
+        self.assertEqual("networkOrgId", network_org.identifier)
+        self.assertEqual("networkOrgName", network_org.name)
+        self.assertEqual("biobankId", network_org.managing_biobank_id)
+        self.assertEqual("contactName", network_org.contact_name)
+        self.assertEqual("contactSurname", network_org.contact_surname)
+        self.assertEqual("contactEmail", network_org.contact_email)
+        self.assertEqual("country", network_org.country)
+        self.assertEqual(["Charter"], network_org.common_collaboration_topics)
+        self.assertEqual("juristicPerson", network_org.juristic_person)

--- a/test/unit/model/test_observation.py
+++ b/test/unit/model/test_observation.py
@@ -46,7 +46,7 @@ class TestObservation(unittest.TestCase):
     def test_observation_to_fhir_ok(self):
         observation = MoFObservation("C51", "sampleId")
         obs_fhir = observation.to_fhir()
-        self.assertEqual("C51", obs_fhir.code.coding[0].code)
+        self.assertEqual("C51", obs_fhir.valueCodeableConcept.coding[0].code)
         self.assertEqual("sampleId", obs_fhir.identifier[0].value)
         self.assertEqual("final", obs_fhir.status)
 


### PR DESCRIPTION
change in the structure - collection and network divided into 2 classses - collection and collection_org, network and network_org respectively. Also no need to use sample_list and network_members, as the model changes also allow to add members directly into the collection and network, with the use of extension (which is an extension that "uses" fhir v5, where members can be a type of Specimen, or Group, or Organization) 