### PR TITLE
Blaze client changes

### DIFF
--- a/miabis_model/collection.py
+++ b/miabis_model/collection.py
@@ -230,7 +230,7 @@ class Collection:
             characteristics = cls._get_characteristics(collection_json["characteristic"])
             managing_collection_fhir_id = parse_reference_id(
                 get_nested_value(collection_json, ["managingEntity", "reference"]))
-            extensions = cls._get_extensions(collection_json["extension"])
+            extensions = cls._get_extensions(collection_json.get("extension", []))
             instance = cls(identifier, name, managing_collection_organization_id, characteristics["sex"],
                            characteristics["material_type"], characteristics["age_range_low"],
                            characteristics["age_range_high"], characteristics["storage_temperature"],

--- a/test/service/test_blaze_client.py
+++ b/test/service/test_blaze_client.py
@@ -48,8 +48,8 @@ class TestBlazeService(unittest.TestCase):
                                                     "description",
                                                     "LifeStyle", "Human", "Environment", ["CaseControl"],
                                                     ["CommercialUse"], ["publication"])
-    example_collection = Collection("collectionId", "collectionName", "collectionOrgId", [Gender.MALE], ["DNA"],
-                                    inclusion_criteria=["HealthStatus"])
+    example_collection = Collection("collectionId", "collectionName", "collectionOrgId", [Gender.MALE], ["DNA"],)
+                                    # inclusion_criteria=["HealthStatus"])
 
     example_network_org = NetworkOrganization("networkOrgId", "networkOrgName", "biobankId", "contactName",
                                               "contactSurname", "contactEmail", "country", ["Charter"],
@@ -101,6 +101,15 @@ class TestBlazeService(unittest.TestCase):
 
     def test_is_resource_present_in_blaze_false(self):
         self.assertFalse(self.blaze_service.is_resource_present_in_blaze("Patient", "nonexistentId"))
+
+    def test_is_resource_present_in_blaze_with_search_param_true(self):
+        self.blaze_service.upload_donor(self.example_donor)
+        self.assertTrue(
+            self.blaze_service.is_resource_present_in_blaze("Patient", self.example_donor.identifier, "identifier"))
+
+    def test_is_resource_present_in_blaze_with_search_param_false(self):
+        self.assertFalse(
+            self.blaze_service.is_resource_present_in_blaze("Patient", "nonexistentIdentifier", "identifier"))
 
     def test_get_fhir_resource_as_json_existing(self):
         donor_fhir_id = self.blaze_service.upload_donor(self.example_donor)
@@ -769,4 +778,3 @@ class TestBlazeService(unittest.TestCase):
         self.assertTrue(updated)
         deleted = self.blaze_service.delete_sample(sample_fhir_id1)
         self.assertTrue(deleted)
-


### PR DESCRIPTION
Change the way of getting value from dictionary in collection from_json() method. use .get() method with default value, so if there are no extensions, no error will be thrown.