### PR TITLE
Blaze client changes

### DIFF
--- a/miabis_model/__init__.py
+++ b/miabis_model/__init__.py
@@ -1,13 +1,13 @@
 from .biobank import Biobank
 from .collection import Collection
-from .collection_organization import CollectionOrganization
+from .collection_organization import _CollectionOrganization
 from .condition import Condition
-from .diagnosis_report import DiagnosisReport
+from .diagnosis_report import _DiagnosisReport
 from .gender import Gender
 from .incorrect_json_format import IncorrectJsonFormatException
-from .network import Network
-from .network_organization import NetworkOrganization
-from .observation import Observation
+from .network import Network, _NetworkOrganization
+# from .network_organization import NetworkOrganization
+from .observation import _Observation
 from .sample import Sample
 from .sample_donor import SampleDonor
 from .storage_temperature import StorageTemperature

--- a/miabis_model/collection_organization.py
+++ b/miabis_model/collection_organization.py
@@ -15,7 +15,7 @@ from miabis_model.util.util import create_country_of_residence, create_contact, 
     create_string_extension, create_fhir_identifier
 
 
-class CollectionOrganization:
+class _CollectionOrganization:
     """Sample Collection represents a set of samples with at least one common characteristic."""
 
     # TODO age range units

--- a/miabis_model/diagnosis_report.py
+++ b/miabis_model/diagnosis_report.py
@@ -12,7 +12,7 @@ from miabis_model.util.parsing_util import get_nested_value, parse_reference_id
 from miabis_model.util.util import create_fhir_identifier
 
 
-class DiagnosisReport:
+class _DiagnosisReport:
     """Class representing a diagnosis report in order to link a specimen to a Condition through this diagnosis report.
     as defined by the MIABIS on FHIR profile.
     """

--- a/miabis_model/network.py
+++ b/miabis_model/network.py
@@ -1,21 +1,27 @@
+import uuid
 from typing import Self
 
+from fhirclient.models.bundle import Bundle
 from fhirclient.models.extension import Extension
 from fhirclient.models.fhirreference import FHIRReference
 from fhirclient.models.group import Group
 from fhirclient.models.meta import Meta
 
+from miabis_model.network_organization import _NetworkOrganization
 from miabis_model.incorrect_json_format import IncorrectJsonFormatException
 from miabis_model.util.config import FHIRConfig
 from miabis_model.util.parsing_util import get_nested_value, parse_reference_id
-from miabis_model.util.util import create_fhir_identifier
+from miabis_model.util.util import create_fhir_identifier, create_post_bundle_entry, create_bundle
 
 
 class Network:
     """Class representing a group of interconnected biobanks or collections with defined common governance"""
 
-    def __init__(self, identifier: str, name: str, network_org_id: str, members_collections_ids: list[str] = None,
-                 members_biobanks_ids: list[str] = None):
+    def __init__(self, identifier: str, name: str, managing_biobank_id: str,
+                 contact_email: str, country: str, juristic_person: str,
+                 members_collections_ids: list[str] = None,
+                 members_biobanks_ids: list[str] = None, contact_name: str = None, contact_surname: str = None,
+                 common_collaboration_topics: list[str] = None, description: str = None):
         """
         :param identifier: network organizational identifier
         :param name: name of the network
@@ -26,13 +32,51 @@ class Network:
         """
         self.identifier = identifier
         self.name = name
-        self.managing_network_org_id = network_org_id
+        self.managing_network_org_id = identifier
         self.members_collections_ids = members_collections_ids
         self.members_biobanks_ids = members_biobanks_ids
+        self._network_org = _NetworkOrganization(identifier=identifier, name=name,
+                                                 managing_biobank_id=managing_biobank_id, contact_name=contact_name,
+                                                 contact_surname=contact_surname, contact_email=contact_email,
+                                                 country=country,
+                                                 common_collaboration_topics=common_collaboration_topics,
+                                                 juristic_person=juristic_person, description=description)
         self._network_fhir_id = None
         self._managing_network_org_fhir_id = None
         self._members_biobanks_fhir_ids = None
         self._members_collections_fhir_ids = None
+
+    @property
+    def description(self):
+        return self._network_org.description
+
+    @property
+    def juristic_person(self) -> str:
+        return self._network_org.juristic_person
+
+    @property
+    def common_collaboration_topics(self) -> list[str]:
+        return self._network_org.common_collaboration_topics
+
+    @property
+    def country(self) -> str:
+        return self._network_org.country
+
+    @property
+    def contact_email(self) -> str:
+        return self._network_org.contact_email
+
+    @property
+    def contact_surname(self) -> str:
+        return self._network_org.contact_surname
+
+    @property
+    def contact_name(self) -> str:
+        return self._network_org.contact_name
+
+    @property
+    def managing_biobank_id(self) -> str:
+        return self._network_org.managing_biobank_id
 
     @property
     def identifier(self) -> str:
@@ -107,7 +151,8 @@ class Network:
         return self._members_biobanks_fhir_ids
 
     @classmethod
-    def from_json(cls, network_json: dict, managing_network_org_id: str, member_collection_ids: list[str],
+    def from_json(cls, network_json: dict, network_org_json: dict, managing_biobank_id: str,
+                  member_collection_ids: list[str],
                   member_biobank_ids: list[str]) -> Self:
         try:
             identifier = get_nested_value(network_json, ["identifier", 0, "value"])
@@ -116,9 +161,19 @@ class Network:
             managing_biobank_fhir_id = parse_reference_id(
                 get_nested_value(network_json, ["managingEntity", "reference"]))
             extensions = cls._parse_extensions(network_json.get("extension", []))
-            instance = cls(identifier, name, managing_network_org_id, member_collection_ids, member_biobank_ids)
+            network_org_instance = _NetworkOrganization.from_json(network_org_json, managing_biobank_id)
+            instance = cls(identifier=identifier, name=name, managing_biobank_id=managing_biobank_id,
+                           contact_name=network_org_instance.contact_name,
+                           contact_surname=network_org_instance.contact_surname,
+                           contact_email=network_org_instance.contact_email, country=network_org_instance.country,
+                           juristic_person=network_org_instance.juristic_person,
+                           members_collections_ids=member_collection_ids,
+                           members_biobanks_ids=member_biobank_ids,
+                           common_collaboration_topics=network_org_instance.common_collaboration_topics,
+                           description=network_org_instance.description)
             instance._network_fhir_id = network_fhir_id
             instance._managing_network_org_fhir_id = managing_biobank_fhir_id
+            instance._network_org = network_org_instance
             instance._members_collections_fhir_ids = extensions["member_collection_fhir_ids"]
             instance._members_biobanks_fhir_ids = extensions["member_biobank_fhir_ids"]
             return instance
@@ -160,6 +215,18 @@ class Network:
         for member_biobank_fhir_id in member_biobank_fhir_ids if member_biobank_fhir_ids is not None else []:
             network.extension.append(self.__create_member_extension("Organization", member_biobank_fhir_id))
         return network
+
+    def build_bundle_for_upload(self, managing_biobank_fhir_id: str, member_collection_fhir_ids: list[str] = None,
+                                member_biobank_fhir_ids: list[str] = None) -> Bundle:
+        network_org_temporary_id = str(uuid.uuid4())
+        network_temporary_id = str(uuid.uuid4())
+        network_org_fhir = self._network_org.to_fhir(managing_biobank_fhir_id)
+        network_fhir = self.to_fhir(network_org_temporary_id, member_collection_fhir_ids, member_biobank_fhir_ids)
+        network_fhir.managingEntity.reference = network_org_temporary_id
+        network_entry = create_post_bundle_entry("Group", network_fhir, network_temporary_id)
+        network_org_entry = create_post_bundle_entry("Organization", network_org_fhir, network_org_temporary_id)
+        bundle = create_bundle([network_entry, network_org_entry])
+        return bundle
 
     @staticmethod
     def __create_member_extension(member_type: str, member_fhir_id: str):

--- a/miabis_model/network_organization.py
+++ b/miabis_model/network_organization.py
@@ -12,13 +12,13 @@ from miabis_model.util.util import create_fhir_identifier, create_contact, creat
     create_codeable_concept_extension, create_string_extension
 
 
-class NetworkOrganization:
+class _NetworkOrganization:
     """Network Organization represent a formal part of a network member,
      like ist name, contact information, url, etc."""
 
-    def __init__(self, identifier: str, name: str, managing_biobank_id: str,
-                 contact_name: str = None, contact_surname: str = None, contact_email: str = None, country: str = None,
-                 common_collaboration_topics: list[str] = None, juristic_person: str = None, description: str = None):
+    def __init__(self, identifier: str, name: str, managing_biobank_id: str, contact_email: str, country: str,
+                 juristic_person: str, contact_name: str = None, contact_surname: str = None,
+                 common_collaboration_topics: list[str] = None, description: str = None):
         """
         :param identifier: network organizational identifier
         :param name: name of the network
@@ -161,9 +161,12 @@ class NetworkOrganization:
             contact = parse_contact(network_json.get("contact", [{}])[0])
             country = get_nested_value(network_json, ["address", 0, "country"])
             parsed_extensions = cls._parse_extensions(network_json.get("extension", []))
-            instance = cls(identifier, name, managing_biobank_id, contact["name"], contact["surname"], contact["email"],
-                           country, parsed_extensions["common_collaboration_topics"],
-                           parsed_extensions["juristic_person"], parsed_extensions["description"])
+            instance = cls(identifier=identifier, name=name, managing_biobank_id=managing_biobank_id,
+                           contact_name=contact["name"],
+                           contact_surname=contact["surname"], contact_email=contact["email"], country=country,
+                           common_collaboration_topics=parsed_extensions["common_collaboration_topics"],
+                           juristic_person=parsed_extensions["juristic_person"],
+                           description=parsed_extensions["description"])
             instance._network_org_fhir_id = network_org_fhir_id
             instance._managing_biobank_fhir_id = managing_biobank_fhir_id
             return instance
@@ -173,9 +176,10 @@ class NetworkOrganization:
     @staticmethod
     def _parse_extensions(extensions: dict) -> dict:
         parsed_extension = {"common_collaboration_topics": [], "juristic_person": None, "description": None}
-        common_coll_topic_extension: str = FHIRConfig.get_extension_url("network_organization","common_collaboration_topics")
-        juristic_person_extension : str = FHIRConfig.get_extension_url("network_organization", "juristic_person")
-        description_extension: str = FHIRConfig.get_extension_url("network_organization","description")
+        common_coll_topic_extension: str = FHIRConfig.get_extension_url("network_organization",
+                                                                        "common_collaboration_topics")
+        juristic_person_extension: str = FHIRConfig.get_extension_url("network_organization", "juristic_person")
+        description_extension: str = FHIRConfig.get_extension_url("network_organization", "description")
         for extension in extensions:
             extension_url = extension["url"]
             if extension_url == common_coll_topic_extension:

--- a/miabis_model/observation.py
+++ b/miabis_model/observation.py
@@ -17,7 +17,7 @@ from miabis_model.util.parsing_util import get_nested_value, parse_reference_id
 from miabis_model.util.util import create_fhir_identifier
 
 
-class Observation:
+class _Observation:
     """Class representing Observation containing an ICD-10 code of deasese as defined by the MIABIS on FHIR profile."""
 
     def __init__(self, icd10_code: str, sample_identifier: str, patient_identifier: str,

--- a/miabis_model/util/util.py
+++ b/miabis_model/util/util.py
@@ -1,4 +1,5 @@
 from fhirclient.models.address import Address
+from fhirclient.models.bundle import BundleEntry, BundleEntryRequest, Bundle
 from fhirclient.models.codeableconcept import CodeableConcept
 from fhirclient.models.coding import Coding
 from fhirclient.models.contactpoint import ContactPoint
@@ -59,3 +60,21 @@ def create_country_of_residence(country: str) -> Address:
     address = Address()
     address.country = country
     return address
+
+
+def create_post_bundle_entry(resource_type: str, resource, temporary_id: str) -> BundleEntry:
+    entry = BundleEntry()
+    entry.request = BundleEntryRequest()
+    entry.fullUrl = temporary_id
+    entry.resource = resource
+    entry.request.method = "POST"
+    entry.request.url = f"/{resource_type}"
+    return entry
+
+
+def create_bundle(entries: list[BundleEntry]) -> Bundle:
+    """Create a bundle used for deleting multiple FHIR resources in a transaction"""
+    bundle = Bundle()
+    bundle.type = "transaction"
+    bundle.entry = entries
+    return bundle

--- a/test/service/test_blaze_client.py
+++ b/test/service/test_blaze_client.py
@@ -7,13 +7,13 @@ from requests.exceptions import HTTPError
 
 from miabis_model import Biobank
 from miabis_model import Collection
-from miabis_model.collection_organization import CollectionOrganization
+from miabis_model.collection_organization import _CollectionOrganization
 from miabis_model import Condition
-from miabis_model import DiagnosisReport
+from miabis_model import _DiagnosisReport
 from miabis_model import Gender
 from miabis_model import Network
-from miabis_model import NetworkOrganization
-from miabis_model.observation import Observation
+from miabis_model import _NetworkOrganization
+from miabis_model.observation import _Observation
 from miabis_model import Sample
 from miabis_model import SampleDonor
 from miabis_model import StorageTemperature
@@ -22,19 +22,24 @@ from blaze_client.blaze_client import BlazeClient
 
 
 class TestBlazeService(unittest.TestCase):
-    example_donor = SampleDonor("donorId", Gender.MALE, datetime.datetime(year=2022, month=10, day=20), "Other")
-    example_samples = [Sample("sampleId", "donorId", "Urine", datetime.datetime(year=2022, month=10, day=20),
-                              storage_temperature=StorageTemperature.TEMPERATURE_LN),
+    example_donor = SampleDonor("donorId", Gender.MALE, datetime.datetime(year=2015, month=10, day=20), "Other")
+    example_samples = [Sample("sampleId", "donorId", "Urine", datetime.datetime(year=2001, month=10, day=20),
+                              storage_temperature=StorageTemperature.TEMPERATURE_LN, diagnoses_with_observed_datetime=[
+            ("C50", datetime.datetime(year=2022, month=10, day=20)),
+            ("C51", datetime.datetime(year=2021, month=10, day=20))]),
                        Sample("sampleId2", "donorId", "Nail", datetime.datetime(year=2020, month=11, day=21),
-                              storage_temperature=StorageTemperature.TEMPERATURE_ROOM)
+                              storage_temperature=StorageTemperature.TEMPERATURE_ROOM,
+                              diagnoses_with_observed_datetime=[
+                                  ("C50", datetime.datetime(year=2020, month=10, day=20)),
+                                  ("C45", datetime.datetime(year=2019, month=10, day=20))])
                        ]
-    example_observations = [Observation("C50", "sampleId", "donorId", datetime.datetime(year=2022, month=10, day=20)),
-                            Observation("C51", "sampleId", "donorId", datetime.datetime(year=2022, month=10, day=20)),
-                            Observation("C50", "sampleId2", "donorId", datetime.datetime(year=2020, month=11, day=21)),
-                            Observation("C45", "sampleId2", "donorId", datetime.datetime(year=2020, month=11, day=21))]
+    example_observations = [_Observation("C50", "sampleId", "donorId", datetime.datetime(year=2022, month=10, day=20)),
+                            _Observation("C51", "sampleId", "donorId", datetime.datetime(year=2022, month=10, day=20)),
+                            _Observation("C50", "sampleId2", "donorId", datetime.datetime(year=2020, month=11, day=21)),
+                            _Observation("C45", "sampleId2", "donorId", datetime.datetime(year=2020, month=11, day=21))]
 
-    example_diagnosis_reports = [DiagnosisReport("sampleId", "donorId"),
-                                 DiagnosisReport("sampleId2", "donorId")]
+    example_diagnosis_reports = [_DiagnosisReport("sampleId", "donorId"),
+                                 _DiagnosisReport("sampleId2", "donorId")]
 
     example_condition = Condition("donorId")
 
@@ -43,19 +48,38 @@ class TestBlazeService(unittest.TestCase):
                               organisational_capabilities=["RecontactDonors"],
                               bioprocessing_and_analysis_capabilities=["Genomics"])
 
-    example_collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
-                                                    "contactSurname", "contactEmail", "cz", "alias", "url",
-                                                    "description",
-                                                    "LifeStyle", "Human", "Environment", ["CaseControl"],
-                                                    ["CommercialUse"], ["publication"])
-    example_collection = Collection("collectionId", "collectionName", "collectionOrgId", [Gender.MALE], ["DNA"],)
-                                    # inclusion_criteria=["HealthStatus"])
+    example_collection = Collection(identifier="collectionId", name="collectionName", managing_biobank_id="biobankId",
+                                    contact_name="contactName", contact_surname="contactSurname",
+                                    contact_email="contactEmail", country="cz", genders=[Gender.MALE],
+                                    material_types=["Urine"], inclusion_criteria=["Sex"],
+                                    alias="collectionAlias", url="urlExample.com", description="description",
+                                    dataset_type="LifeStyle", sample_source="Human",
+                                    sample_collection_setting="Environment", collection_design=["CaseControl"],
+                                    use_and_access_conditions=["CommercialUse"], publications=["publication"])
 
-    example_network_org = NetworkOrganization("networkOrgId", "networkOrgName", "biobankId", "contactName",
-                                              "contactSurname", "contactEmail", "country", ["Charter"],
-                                              "juristicPerson")
+    example_network = Network(identifier="networkId", name="networkName", managing_biobank_id="biobankId",
+                              contact_email="contactEmail", country="cz", juristic_person="juristicPerson",
+                              members_collections_ids=["collectionId"],
+                              members_biobanks_ids=["biobankId"], contact_name="contactName",
+                              contact_surname="contactSurname", common_collaboration_topics=["Charter"],
+                              description="description")
 
-    example_network = Network("networkId", "networkName", "networkOrgId", ["collectionId"], ["biobankId"])
+    example_collection_org = _CollectionOrganization("collectionId", "collectionOrgName", "biobankId", "contactName",
+                                                     "contactSurname", "contactEmail", "cz", "alias", "url",
+                                                     "description",
+                                                     "LifeStyle", "Human", "Environment", ["CaseControl"],
+                                                     ["CommercialUse"], ["publication"])
+    # example_collection = Collection("collectionId", "collectionName", "collectionOrgId", [Gender.MALE], ["DNA"],)
+    #                                 # inclusion_criteria=["HealthStatus"])
+    #
+    example_network_org = _NetworkOrganization(identifier="networkId", name="networkName",
+                                               managing_biobank_id="biobankId", contact_email="contactEmail",
+                                               contact_surname="contactSurname", contact_name="contactName",
+                                               country="country", common_collaboration_topics=["Charter"],
+                                               juristic_person="juristicPerson", description="description")
+
+    #
+    # example_network = Network("networkId", "networkName", "networkOrgId", ["collectionId"], ["biobankId"])
 
     @pytest.fixture(autouse=True)
     def run_around_tests(self):
@@ -81,14 +105,18 @@ class TestBlazeService(unittest.TestCase):
             collection_org_fhir_id = self.blaze_service.get_fhir_id("Organization",
                                                                     self.example_collection_org.identifier)
             if collection_org_fhir_id is not None:
-                if not self.blaze_service.delete_collection_organization(collection_org_fhir_id):
+                if not self.blaze_service._delete_collection_organization(collection_org_fhir_id):
                     raise Exception("could not delete collection organization")
             network_org_fhir_id = self.blaze_service.get_fhir_id("Organization", self.example_network_org.identifier)
             if network_org_fhir_id is not None:
-                if not self.blaze_service.delete_network_organization(network_org_fhir_id):
+                if not self.blaze_service._delete_network_organization(network_org_fhir_id):
                     raise Exception("could not delete network organization")
         except NonExistentResourceException:
             pass
+
+    def test_upload_sample_chain(self):
+        donor_fhir_id = self.blaze_service.upload_donor(self.example_donor)
+        self.blaze_service.upload_sample(self.example_samples[0])
 
     def test_is_resource_present_in_blaze_true(self):
         donor_fhir_id = self.blaze_service.upload_donor(self.example_donor)
@@ -240,26 +268,24 @@ class TestBlazeService(unittest.TestCase):
 
     def test_upload_observation(self):
         self.blaze_service.upload_donor(self.example_donor)
-        self.blaze_service.upload_sample(self.example_samples[0])
-        obs_fhir_id1 = self.blaze_service.upload_observation(self.example_observations[0])
-        obs_fhir_id2 = self.blaze_service.upload_observation(self.example_observations[1])
-        self.assertTrue(self.blaze_service.is_resource_present_in_blaze("Observation", obs_fhir_id1))
-        self.assertTrue(self.blaze_service.is_resource_present_in_blaze("Observation", obs_fhir_id2))
+        sample_fhir_id = self.blaze_service.upload_sample(self.example_samples[0])
+        observation_fhir_ids = self.blaze_service._get_observation_fhir_ids_belonging_to_sample(sample_fhir_id)
+        self.assertIsNotNone(observation_fhir_ids)
 
     def test_upload_observation_with_nonexistent_sample_riases_nonexistentresource_exception(self):
         self.blaze_service.upload_donor(self.example_donor)
         with self.assertRaises(NonExistentResourceException):
-            self.blaze_service.upload_observation(self.example_observations[0])
+            self.blaze_service._upload_observation(self.example_observations[0])
 
     def test_upload_observation_with_nonexistent_donor_riases_nonexistentresource_exception(self):
         with self.assertRaises(NonExistentResourceException):
-            self.blaze_service.upload_observation(self.example_observations[0])
+            self.blaze_service._upload_observation(self.example_observations[0])
 
     def test_build_observation_from_json(self):
         donor_fhir_id = self.blaze_service.upload_donor(self.example_donor)
         sample_fhir_id = self.blaze_service.upload_sample(self.example_samples[0])
-        obs_fhir_id1 = self.blaze_service.upload_observation(self.example_observations[0])
-        build_observation = self.blaze_service.build_observation_from_json(obs_fhir_id1)
+        obs_fhir_id1 = self.blaze_service._upload_observation(self.example_observations[0])
+        build_observation = self.blaze_service._build_observation_from_json(obs_fhir_id1)
         self.assertEqual(build_observation.observation_fhir_id, obs_fhir_id1)
         self.assertEqual(build_observation.sample_fhir_id, sample_fhir_id)
         self.assertEqual(build_observation.patient_fhir_id, donor_fhir_id)
@@ -270,89 +296,89 @@ class TestBlazeService(unittest.TestCase):
     def test_build_observation_from_json_nonexistent_fhir_id_raises_nonexistent_exception(self):
         donor_fhir_id = self.blaze_service.upload_donor(self.example_donor)
         sample_fhir_id = self.blaze_service.upload_sample(self.example_samples[0])
-        obs_fhir_id1 = self.blaze_service.upload_observation(self.example_observations[0])
+        obs_fhir_id1 = self.blaze_service._upload_observation(self.example_observations[0])
         with self.assertRaises(NonExistentResourceException):
-            self.blaze_service.build_observation_from_json("nonexistentId")
+            self.blaze_service._build_observation_from_json("nonexistentId")
 
     def test_update_observation(self):
         self.blaze_service.upload_donor(self.example_donor)
         self.blaze_service.upload_sample(self.example_samples[0])
-        obs_fhir_id1 = self.blaze_service.upload_observation(self.example_observations[0])
-        update_observation = self.blaze_service.build_observation_from_json(obs_fhir_id1)
+        obs_fhir_id1 = self.blaze_service._upload_observation(self.example_observations[0])
+        update_observation = self.blaze_service._build_observation_from_json(obs_fhir_id1)
         update_observation.icd10_code = "C34"
         update_observation_fhir = update_observation.add_fhir_id_to_observation(update_observation.to_fhir())
         updated = self.blaze_service.update_fhir_resource("Observation", obs_fhir_id1,
                                                           update_observation_fhir.as_json())
         self.assertTrue(updated)
-        updated_observation = self.blaze_service.build_observation_from_json(obs_fhir_id1)
+        updated_observation = self.blaze_service._build_observation_from_json(obs_fhir_id1)
         self.assertEqual(updated_observation.icd10_code, update_observation.icd10_code)
-        self.blaze_service.delete_observation(obs_fhir_id1)
+        self.blaze_service._delete_observation(obs_fhir_id1)
 
     def test_delete_observation(self):
         self.blaze_service.upload_donor(self.example_donor)
         self.blaze_service.upload_sample(self.example_samples[0])
-        observation_fhir_id = self.blaze_service.upload_observation(self.example_observations[0])
-        deleted = self.blaze_service.delete_observation(observation_fhir_id)
+        observation_fhir_id = self.blaze_service._upload_observation(self.example_observations[0])
+        deleted = self.blaze_service._delete_observation(observation_fhir_id)
         self.assertTrue(deleted)
         self.assertFalse(self.blaze_service.is_resource_present_in_blaze("Observation", observation_fhir_id))
 
     def test_delete_observation_with_nonexistent_fhir_id_raises_nonexistent_exception(self):
         self.blaze_service.upload_donor(self.example_donor)
         self.blaze_service.upload_sample(self.example_samples[0])
-        observation_fhir_id = self.blaze_service.upload_observation(self.example_observations[0])
+        observation_fhir_id = self.blaze_service._upload_observation(self.example_observations[0])
         with self.assertRaises(NonExistentResourceException):
-            self.blaze_service.delete_observation("nonexistentId")
+            self.blaze_service._delete_observation("nonexistentId")
 
     def test_upload_diagnosis_report(self):
         self.blaze_service.upload_donor(self.example_donor)
         self.blaze_service.upload_sample(self.example_samples[0])
-        diagnosis_report_fhir_id = self.blaze_service.upload_diagnosis_report(self.example_diagnosis_reports[0])
+        diagnosis_report_fhir_id = self.blaze_service._upload_diagnosis_report(self.example_diagnosis_reports[0])
         self.assertIsNotNone(diagnosis_report_fhir_id)
 
     def test_upload_diagnosis_report_with_nonexistent_donor_raises_nonexistent_exception(self):
         with self.assertRaises(NonExistentResourceException):
-            self.blaze_service.upload_diagnosis_report(self.example_diagnosis_reports[0])
+            self.blaze_service._upload_diagnosis_report(self.example_diagnosis_reports[0])
 
     def test_upload_diagnosis_report_with_nonexistent_sample_raises_nonexistent_exception(self):
         self.blaze_service.upload_donor(self.example_donor)
         with self.assertRaises(NonExistentResourceException):
-            self.blaze_service.upload_diagnosis_report(self.example_diagnosis_reports[0])
+            self.blaze_service._upload_diagnosis_report(self.example_diagnosis_reports[0])
 
     def test_build_diagnosis_report_from_json(self):
         donor_fhir_id = self.blaze_service.upload_donor(self.example_donor)
         sample_fhir_id = self.blaze_service.upload_sample(self.example_samples[0])
-        diagnosis_report_fhir_id = self.blaze_service.upload_diagnosis_report(self.example_diagnosis_reports[0])
-        build_diagnosis_report = self.blaze_service.build_diagnosis_report_from_json(diagnosis_report_fhir_id)
+        diagnosis_report_fhir_id = self.blaze_service._upload_diagnosis_report(self.example_diagnosis_reports[0])
+        build_diagnosis_report = self.blaze_service._build_diagnosis_report_from_json(diagnosis_report_fhir_id)
         self.assertEqual(build_diagnosis_report.sample_fhir_id, sample_fhir_id)
         self.assertEqual(build_diagnosis_report.patient_fhir_id, donor_fhir_id)
 
     def test_build_diagnosis_report_from_json_with_nonexistent_fhir_id_raises_nonexistent_exception(self):
         self.blaze_service.upload_donor(self.example_donor)
         self.blaze_service.upload_sample(self.example_samples[0])
-        self.blaze_service.upload_diagnosis_report(self.example_diagnosis_reports[0])
+        self.blaze_service._upload_diagnosis_report(self.example_diagnosis_reports[0])
         with self.assertRaises(NonExistentResourceException):
-            self.blaze_service.build_diagnosis_report_from_json("nonexistentId")
+            self.blaze_service._build_diagnosis_report_from_json("nonexistentId")
 
     def test_upload_diagnosis_report_along_with_observations(self):
         self.blaze_service.upload_donor(self.example_donor)
         self.blaze_service.upload_sample(self.example_samples[0])
         self.blaze_service.upload_sample(self.example_samples[1])
-        self.blaze_service.upload_observation(self.example_observations[0])
-        self.blaze_service.upload_observation(self.example_observations[1])
-        self.blaze_service.upload_observation(self.example_observations[2])
-        diagnosis_report_fhir_id = self.blaze_service.upload_diagnosis_report(self.example_diagnosis_reports[0])
-        diagnosis_report_fhir_id2 = self.blaze_service.upload_diagnosis_report(self.example_diagnosis_reports[1])
+        self.blaze_service._upload_observation(self.example_observations[0])
+        self.blaze_service._upload_observation(self.example_observations[1])
+        self.blaze_service._upload_observation(self.example_observations[2])
+        diagnosis_report_fhir_id = self.blaze_service._upload_diagnosis_report(self.example_diagnosis_reports[0])
+        diagnosis_report_fhir_id2 = self.blaze_service._upload_diagnosis_report(self.example_diagnosis_reports[1])
         self.assertTrue(self.blaze_service.is_resource_present_in_blaze("DiagnosticReport", diagnosis_report_fhir_id))
         self.assertIsNotNone(
-            self.blaze_service.get_observation_fhir_ids_belonging_to_diagnosis_report(diagnosis_report_fhir_id))
+            self.blaze_service._get_observation_fhir_ids_belonging_to_diagnosis_report(diagnosis_report_fhir_id))
 
     def test_build_diagnosis_report_along_with_observations_from_json(self):
         donor_fhir_id = self.blaze_service.upload_donor(self.example_donor)
         sample_fhir_id = self.blaze_service.upload_sample(self.example_samples[0])
-        obs1_fhir_id = self.blaze_service.upload_observation(self.example_observations[0])
-        obs2_fhir_id = self.blaze_service.upload_observation(self.example_observations[1])
-        diagnosis_report_fhir_id = self.blaze_service.upload_diagnosis_report(self.example_diagnosis_reports[0])
-        build_diagnosis_report = self.blaze_service.build_diagnosis_report_from_json(diagnosis_report_fhir_id)
+        obs1_fhir_id = self.blaze_service._upload_observation(self.example_observations[0])
+        obs2_fhir_id = self.blaze_service._upload_observation(self.example_observations[1])
+        diagnosis_report_fhir_id = self.blaze_service._upload_diagnosis_report(self.example_diagnosis_reports[0])
+        build_diagnosis_report = self.blaze_service._build_diagnosis_report_from_json(diagnosis_report_fhir_id)
         self.assertEqual(build_diagnosis_report.sample_fhir_id, sample_fhir_id)
         self.assertEqual(build_diagnosis_report.patient_fhir_id, donor_fhir_id)
         self.assertIn(obs1_fhir_id, build_diagnosis_report.observations_fhir_identifiers)
@@ -361,30 +387,30 @@ class TestBlazeService(unittest.TestCase):
     def test_delete_diagnosis_report_without_observations(self):
         self.blaze_service.upload_donor(self.example_donor)
         sample_fhir_id = self.blaze_service.upload_sample(self.example_samples[0])
-        diagnosis_report_fhir_id = self.blaze_service.upload_diagnosis_report(self.example_diagnosis_reports[0])
-        deleted = self.blaze_service.delete_diagnosis_report(diagnosis_report_fhir_id)
+        diagnosis_report_fhir_id = self.blaze_service._upload_diagnosis_report(self.example_diagnosis_reports[0])
+        deleted = self.blaze_service._delete_diagnosis_report(diagnosis_report_fhir_id)
         self.assertTrue(deleted)
 
     def test_delete_diagnosis_report_with_observations(self):
         self.blaze_service.upload_donor(self.example_donor)
         self.blaze_service.upload_sample(self.example_samples[0])
-        self.blaze_service.upload_observation(self.example_observations[0])
-        self.blaze_service.upload_observation(self.example_observations[1])
-        diagnosis_report_fhir_id = self.blaze_service.upload_diagnosis_report(self.example_diagnosis_reports[0])
-        deleted = self.blaze_service.delete_diagnosis_report(diagnosis_report_fhir_id)
+        self.blaze_service._upload_observation(self.example_observations[0])
+        self.blaze_service._upload_observation(self.example_observations[1])
+        diagnosis_report_fhir_id = self.blaze_service._upload_diagnosis_report(self.example_diagnosis_reports[0])
+        deleted = self.blaze_service._delete_diagnosis_report(diagnosis_report_fhir_id)
         self.assertTrue(deleted)
         self.assertFalse(self.blaze_service.is_resource_present_in_blaze("DiagnosticReport", diagnosis_report_fhir_id))
 
     def test_delete_diagnosis_report_referenced_in_condition(self):
         self.blaze_service.upload_donor(self.example_donor)
         self.blaze_service.upload_sample(self.example_samples[0])
-        self.blaze_service.upload_observation(self.example_observations[0])
-        self.blaze_service.upload_observation(self.example_observations[1])
-        diagnosis_report_fhir_id = self.blaze_service.upload_diagnosis_report(self.example_diagnosis_reports[0])
+        self.blaze_service._upload_observation(self.example_observations[0])
+        self.blaze_service._upload_observation(self.example_observations[1])
+        diagnosis_report_fhir_id = self.blaze_service._upload_diagnosis_report(self.example_diagnosis_reports[0])
         condition_fhir_id = self.blaze_service.upload_condition(self.example_condition)
         condition = self.blaze_service.build_condition_from_json(condition_fhir_id)
         self.assertIn(diagnosis_report_fhir_id, condition.diagnosis_report_fhir_ids)
-        deleted = self.blaze_service.delete_diagnosis_report(diagnosis_report_fhir_id)
+        deleted = self.blaze_service._delete_diagnosis_report(diagnosis_report_fhir_id)
         self.assertTrue(deleted)
         condition_without_diagnosis_report = self.blaze_service.build_condition_from_json(condition_fhir_id)
         self.assertNotIn(diagnosis_report_fhir_id, condition_without_diagnosis_report.diagnosis_report_fhir_ids)
@@ -426,6 +452,12 @@ class TestBlazeService(unittest.TestCase):
         self.assertEqual(update_condition.icd_10_code, updated_condition.icd_10_code)
         self.blaze_service.delete_condition(condition_fhir_id)
 
+    def test_add_diagnosis_to_condition(self):
+        patient_fhir_id = self.blaze_service.upload_donor(self.example_donor)
+        condition_fhir_id = self.blaze_service.upload_condition(self.example_condition)
+        sample_fhir_id = self.blaze_service.upload_sample(self.example_samples[0])
+        self.assertTrue(self.blaze_service.add_diagnoses_to_condition(condition_fhir_id, sample_fhir_id))
+
     def test_delete_condition_with_no_diagnosis_reports(self):
         self.blaze_service.upload_donor(self.example_donor)
         self.blaze_service.upload_sample(self.example_samples[0])
@@ -437,8 +469,8 @@ class TestBlazeService(unittest.TestCase):
     def test_delete_condition_with_diagnosis_reports(self):
         self.blaze_service.upload_donor(self.example_donor)
         self.blaze_service.upload_sample(self.example_samples[0])
-        self.blaze_service.upload_observation(self.example_observations[0])
-        self.blaze_service.upload_diagnosis_report(self.example_diagnosis_reports[0])
+        self.blaze_service._upload_observation(self.example_observations[0])
+        self.blaze_service._upload_diagnosis_report(self.example_diagnosis_reports[0])
         condition_fhir_id = self.blaze_service.upload_condition(self.example_condition)
         deleted = self.blaze_service.delete_condition(condition_fhir_id)
         self.assertTrue(deleted)
@@ -456,17 +488,17 @@ class TestBlazeService(unittest.TestCase):
         self.blaze_service.upload_sample(self.example_samples[0])
         # diagnosis_report_fhir_id = self.blaze_service.get_diagnosis_report_fhir_id_belonging_to_sample(sample_fhir_id)
         condition_fhir_id = self.blaze_service.upload_condition(self.example_condition)
-        diagnosis_report_fhir_id = self.blaze_service.upload_diagnosis_report(self.example_diagnosis_reports[0])
-        dig_rep_added = self.blaze_service.add_diagnosis_reports_to_condition(condition_fhir_id,
-                                                                              [diagnosis_report_fhir_id])
+        diagnosis_report_fhir_id = self.blaze_service._upload_diagnosis_report(self.example_diagnosis_reports[0])
+        dig_rep_added = self.blaze_service._add_diagnosis_reports_to_condition(condition_fhir_id,
+                                                                               [diagnosis_report_fhir_id])
         self.assertTrue(dig_rep_added)
 
     def test_get_observation_fhir_ids_belonging_to_sample(self):
         self.blaze_service.upload_donor(self.example_donor)
         sample_fhir_id = self.blaze_service.upload_sample(self.example_samples[0])
-        obs_fhir_id1 = self.blaze_service.upload_observation(self.example_observations[0])
-        obs_fhir_id2 = self.blaze_service.upload_observation(self.example_observations[1])
-        obs_fhir_ids = self.blaze_service.get_observation_fhir_ids_belonging_to_sample(sample_fhir_id)
+        obs_fhir_id1 = self.blaze_service._upload_observation(self.example_observations[0])
+        obs_fhir_id2 = self.blaze_service._upload_observation(self.example_observations[1])
+        obs_fhir_ids = self.blaze_service._get_observation_fhir_ids_belonging_to_sample(sample_fhir_id)
         self.assertTrue(len(obs_fhir_ids) != 0)
         self.assertIn(obs_fhir_id1, obs_fhir_ids)
         self.assertIn(obs_fhir_id2, obs_fhir_ids)
@@ -476,35 +508,32 @@ class TestBlazeService(unittest.TestCase):
         sample_fhir_ids = []
         for sample in self.example_samples:
             sample_fhir_ids.append(self.blaze_service.upload_sample(sample))
-        observation_fhir_ids = []
-        for observation in self.example_observations:
-            observation_fhir_ids.append(self.blaze_service.upload_observation(observation))
-        diagnosis_reports_fhir_ids = []
-        for diagnosis_report in self.example_diagnosis_reports:
-            diagnosis_reports_fhir_ids.append(self.blaze_service.upload_diagnosis_report(diagnosis_report))
         condition_fhir_id = self.blaze_service.upload_condition(self.example_condition)
-        self.assertIsNotNone(donor_fhir_id)
+        observation_fhir_ids = []
+        diagnosis_fhir_ids = []
         for sample_fhir_id in sample_fhir_ids:
             self.assertIsNotNone(sample_fhir_id)
-        for observation_fhir_id in observation_fhir_ids:
-            self.assertIsNotNone(observation_fhir_id)
-        for diagnosis_report_fhir_id in diagnosis_reports_fhir_ids:
-            self.assertIsNotNone(diagnosis_report_fhir_id)
+            observation_fhir_ids.extend(
+                self.blaze_service._get_observation_fhir_ids_belonging_to_sample(sample_fhir_id))
+            diagnosis_fhir_ids.append(
+                self.blaze_service._get_diagnosis_report_fhir_id_belonging_to_sample(sample_fhir_id))
+        self.assertIsNotNone(donor_fhir_id)
+        self.assertIsNotNone(observation_fhir_ids)
+        self.assertEqual(4, len(observation_fhir_ids))
+        self.assertEqual(2, len(diagnosis_fhir_ids))
         self.assertIsNotNone(condition_fhir_id)
-        diag_report_for_first_sample = self.blaze_service.get_diagnosis_report_fhir_id_belonging_to_sample(
+        diag_report_for_first_sample = self.blaze_service._get_diagnosis_report_fhir_id_belonging_to_sample(
             sample_fhir_ids[0])
-        diag_report_for_second_sample = self.blaze_service.get_diagnosis_report_fhir_id_belonging_to_sample(
+        diag_report_for_second_sample = self.blaze_service._get_diagnosis_report_fhir_id_belonging_to_sample(
             sample_fhir_ids[1])
-        observations_for_first_sample = self.blaze_service.get_observation_fhir_ids_belonging_to_sample(
+        observations_for_first_sample = self.blaze_service._get_observation_fhir_ids_belonging_to_sample(
             sample_fhir_ids[0])
-        observations_for_second_sample = self.blaze_service.get_observation_fhir_ids_belonging_to_sample(
+        observations_for_second_sample = self.blaze_service._get_observation_fhir_ids_belonging_to_sample(
             sample_fhir_ids[1])
         for obs_sample_1 in observations_for_first_sample:
             self.assertIn(obs_sample_1, observation_fhir_ids)
         for obs_sample_2 in observations_for_second_sample:
             self.assertIn(obs_sample_2, observation_fhir_ids)
-        self.assertEqual(diag_report_for_first_sample, diagnosis_reports_fhir_ids[0])
-        self.assertEqual(diag_report_for_second_sample, diagnosis_reports_fhir_ids[1])
 
     def test_upload_biobank(self):
         biobank_fhir_id = self.blaze_service.upload_biobank(self.example_biobank)
@@ -531,20 +560,34 @@ class TestBlazeService(unittest.TestCase):
         with self.assertRaises(NonExistentResourceException):
             self.blaze_service.build_biobank_from_json("nonexistentId")
 
+    def test_upload_collection(self):
+        biobank_fhir_id = self.blaze_service.upload_biobank(self.example_biobank)
+        collection_fhir_id = self.blaze_service.upload_collection(self.example_collection)
+        self.assertIsNotNone(collection_fhir_id)
+        self.assertTrue(self.blaze_service.is_resource_present_in_blaze("Group", collection_fhir_id))
+
+    def test_delete_collection(self):
+        self.blaze_service.upload_biobank(self.example_biobank)
+        collection_fhir_id = self.blaze_service.upload_collection(self.example_collection)
+        self.assertTrue(self.blaze_service.is_resource_present_in_blaze("Group", collection_fhir_id))
+        deleted = self.blaze_service.delete_collection(collection_fhir_id)
+        self.assertTrue(deleted)
+        self.assertFalse(self.blaze_service.is_resource_present_in_blaze("Group", collection_fhir_id))
+
     def test_upload_collection_organization(self):
         self.blaze_service.upload_biobank(self.example_biobank)
-        collection_organization_id = self.blaze_service.upload_collection_organization(self.example_collection_org)
+        collection_organization_id = self.blaze_service._upload_collection_organization(self.example_collection_org)
         self.assertIsNotNone(collection_organization_id)
         self.assertTrue(self.blaze_service.is_resource_present_in_blaze("Organization", collection_organization_id))
 
     def test_upload_collection_organization_with_nonexistent_biobank_raises_nonexistent_exception(self):
         with self.assertRaises(NonExistentResourceException):
-            self.blaze_service.upload_collection_organization(self.example_collection_org)
+            self.blaze_service._upload_collection_organization(self.example_collection_org)
 
     def test_build_collection_organization_from_json(self):
         biobank_fhir_id = self.blaze_service.upload_biobank(self.example_biobank)
-        collection_organization_id = self.blaze_service.upload_collection_organization(self.example_collection_org)
-        collection_org = self.blaze_service.build_collection_organization_from_json(collection_organization_id)
+        collection_organization_id = self.blaze_service._upload_collection_organization(self.example_collection_org)
+        collection_org = self.blaze_service._build_collection_organization_from_json(collection_organization_id)
         self.assertEqual(collection_org.identifier, self.example_collection_org.identifier)
         self.assertEqual(collection_org.name, self.example_collection_org.name)
         self.assertEqual(collection_org.alias, self.example_collection_org.alias)
@@ -565,17 +608,17 @@ class TestBlazeService(unittest.TestCase):
         self.assertEqual(collection_org.description, self.example_collection_org.description)
         self.assertEqual(biobank_fhir_id, collection_org.managing_biobank_fhir_id)
 
-    def test_upload_collection(self):
+    def test_upload_collection_private(self):
         self.blaze_service.upload_biobank(self.example_biobank)
-        self.blaze_service.upload_collection_organization(self.example_collection_org)
-        collection_fhir_id = self.blaze_service.upload_collection(self.example_collection)
+        self.blaze_service._upload_collection_organization(self.example_collection_org)
+        collection_fhir_id = self.blaze_service._upload_collection(self.example_collection)
         self.assertIsNotNone(collection_fhir_id)
         self.assertTrue(self.blaze_service.is_resource_present_in_blaze("Group", collection_fhir_id))
 
     def test_build_collection_from_json(self):
         self.blaze_service.upload_biobank(self.example_biobank)
-        collection_org_fhir_id = self.blaze_service.upload_collection_organization(self.example_collection_org)
-        collection_fhir_id = self.blaze_service.upload_collection(self.example_collection)
+        collection_org_fhir_id = self.blaze_service._upload_collection_organization(self.example_collection_org)
+        collection_fhir_id = self.blaze_service._upload_collection(self.example_collection)
         collection = self.blaze_service.build_collection_from_json(collection_fhir_id)
         self.assertEqual(self.example_collection.name, collection.name)
         self.assertEqual(self.example_collection.identifier, collection.identifier)
@@ -595,22 +638,22 @@ class TestBlazeService(unittest.TestCase):
     def test_upload_collection_with_nonexistent_organization_raises_nonexistent_exception(self):
         self.blaze_service.upload_biobank(self.example_biobank)
         with self.assertRaises(NonExistentResourceException):
-            self.blaze_service.upload_collection(self.example_collection)
+            self.blaze_service._upload_collection(self.example_collection)
 
     def test_upload_network_organization(self):
         self.blaze_service.upload_biobank(self.example_biobank)
-        network_org_fhir_id = self.blaze_service.upload_network_organization(self.example_network_org)
+        network_org_fhir_id = self.blaze_service._upload_network_organization(self.example_network_org)
         self.assertIsNotNone(network_org_fhir_id)
         self.assertTrue(self.blaze_service.is_resource_present_in_blaze("Organization", network_org_fhir_id))
 
     def test_upload_network_organization_with_nonexistent_biobank_raises_nonexistent_exception(self):
         with self.assertRaises(NonExistentResourceException):
-            self.blaze_service.upload_network_organization(self.example_network_org)
+            self.blaze_service._upload_network_organization(self.example_network_org)
 
     def test_build_network_organization_from_json(self):
         biobank_fhir_id = self.blaze_service.upload_biobank(self.example_biobank)
-        network_org_fhir_id = self.blaze_service.upload_network_organization(self.example_network_org)
-        network_org = self.blaze_service.build_network_org_from_json(network_org_fhir_id)
+        network_org_fhir_id = self.blaze_service._upload_network_organization(self.example_network_org)
+        network_org = self.blaze_service._build_network_org_from_json(network_org_fhir_id)
         self.assertEqual(network_org.network_org_fhir_id, network_org_fhir_id)
         self.assertEqual(network_org.name, self.example_network_org.name)
         self.assertEqual(network_org.identifier, self.example_network_org.identifier)
@@ -626,24 +669,39 @@ class TestBlazeService(unittest.TestCase):
 
     def test_upload_network(self):
         self.blaze_service.upload_biobank(self.example_biobank)
-        self.blaze_service.upload_collection_organization(self.example_collection_org)
         self.blaze_service.upload_collection(self.example_collection)
-        self.blaze_service.upload_network_organization(self.example_network_org)
+        network_id = self.blaze_service.upload_network(self.example_network)
+        self.assertTrue(self.blaze_service.is_resource_present_in_blaze("Group", network_id))
+        self.assertIsNotNone(network_id)
+
+    def test_delete_network(self):
+        self.blaze_service.upload_biobank(self.example_biobank)
+        self.blaze_service.upload_collection(self.example_collection)
         network_fhir_id = self.blaze_service.upload_network(self.example_network)
+        deleted = self.blaze_service.delete_network(network_fhir_id)
+        self.assertTrue(deleted)
+        self.assertFalse(self.blaze_service.is_resource_present_in_blaze("Group", network_fhir_id))
+
+    def test_upload_network_private(self):
+        self.blaze_service.upload_biobank(self.example_biobank)
+        self.blaze_service._upload_collection_organization(self.example_collection_org)
+        self.blaze_service._upload_collection(self.example_collection)
+        self.blaze_service._upload_network_organization(self.example_network_org)
+        network_fhir_id = self.blaze_service._upload_network(self.example_network)
         self.assertIsNotNone(network_fhir_id)
         self.assertTrue(self.blaze_service.is_resource_present_in_blaze("Group", network_fhir_id))
 
     def test_upload_network_with_nonexistent_network_organization_raises_nonexistent_exception(self):
         self.blaze_service.upload_biobank(self.example_biobank)
         with self.assertRaises(NonExistentResourceException):
-            self.blaze_service.upload_network(self.example_network)
+            self.blaze_service._upload_network(self.example_network)
 
     def test_build_network_from_json(self):
         biobank_fhir_id = self.blaze_service.upload_biobank(self.example_biobank)
-        collection_org_fhir_id = self.blaze_service.upload_collection_organization(self.example_collection_org)
-        collection_fhir_id = self.blaze_service.upload_collection(self.example_collection)
-        network_org_fhir_id = self.blaze_service.upload_network_organization(self.example_network_org)
-        network_fhir_id = self.blaze_service.upload_network(self.example_network)
+        collection_org_fhir_id = self.blaze_service._upload_collection_organization(self.example_collection_org)
+        collection_fhir_id = self.blaze_service._upload_collection(self.example_collection)
+        network_org_fhir_id = self.blaze_service._upload_network_organization(self.example_network_org)
+        network_fhir_id = self.blaze_service._upload_network(self.example_network)
         network = self.blaze_service.build_network_from_json(network_fhir_id)
         self.assertEqual(network_fhir_id, network.network_fhir_id)
         self.assertEqual(network_org_fhir_id, network.managing_network_org_fhir_id)
@@ -665,14 +723,16 @@ class TestBlazeService(unittest.TestCase):
         self.blaze_service.upload_donor(self.example_donor)
         sample_fhir_id1 = self.blaze_service.upload_sample(self.example_samples[0])
         sample_fhir_id2 = self.blaze_service.upload_sample(self.example_samples[1])
-        self.blaze_service.upload_observation(self.example_observations[0])
-        self.blaze_service.upload_observation(self.example_observations[1])
-        self.blaze_service.upload_diagnosis_report(self.example_diagnosis_reports[0])
+        # self.blaze_service._upload_observation(self.example_observations[0])
+        # self.blaze_service._upload_observation(self.example_observations[1])
+        # self.blaze_service._upload_diagnosis_report(self.example_diagnosis_reports[0])
         self.blaze_service.upload_biobank(self.example_biobank)
-        self.blaze_service.upload_network_organization(self.example_network_org)
-        self.blaze_service.upload_collection_organization(self.example_collection_org)
         collection_fhir_id = self.blaze_service.upload_collection(self.example_collection)
         self.blaze_service.upload_network(self.example_network)
+        # self.blaze_service._upload_network_organization(self.example_network_org)
+        # self.blaze_service._upload_collection_organization(self.example_collection_org)
+        # collection_fhir_id = self.blaze_service._upload_collection(self.example_collection)
+        # self.blaze_service._upload_network(self.example_network)
         updated = self.blaze_service.add_already_present_samples_to_existing_collection(
             [sample_fhir_id1, sample_fhir_id2], collection_fhir_id)
         self.assertTrue(updated)
@@ -689,21 +749,15 @@ class TestBlazeService(unittest.TestCase):
     def test_update_collection_values_after_deleting_sample(self):
         self.blaze_service.upload_donor(self.example_donor)
         sample_fhir_id1 = self.blaze_service.upload_sample(self.example_samples[0])
-        self.blaze_service.upload_observation(self.example_observations[0])
-        self.blaze_service.upload_diagnosis_report(self.example_diagnosis_reports[0])
         new_sample = Sample("newSampleId", "newDonorId", "Nail", datetime.datetime(year=2020, month=11, day=21),
-                            storage_temperature=StorageTemperature.TEMPERATURE_OTHER)
-        new_donor = SampleDonor("newDonorId", Gender.FEMALE, datetime.datetime(year=2000, month=10, day=20), "Other")
-        new_observation = Observation("B22", "newSampleId", "newDonorId",
-                                      datetime.datetime(year=2019, month=10, day=20))
-        new_diagnosis_report = DiagnosisReport("newSampleId", "newDonorId")
+                            storage_temperature=StorageTemperature.TEMPERATURE_OTHER,
+                            diagnoses_with_observed_datetime=[("B22", datetime.datetime(year=2019, month=10, day=20))])
+        new_donor = SampleDonor("newDonorId", Gender.FEMALE, datetime.datetime(year=1980, month=10, day=20), "Other")
         new_donor_fhir_id = self.blaze_service.upload_donor(new_donor)
         new_sample_fhir_id = self.blaze_service.upload_sample(new_sample)
-        new_observation_fhir_id = self.blaze_service.upload_observation(new_observation)
-        new_diagnosis_report_fhir_id = self.blaze_service.upload_diagnosis_report(new_diagnosis_report)
         self.blaze_service.upload_biobank(self.example_biobank)
-        self.blaze_service.upload_collection_organization(self.example_collection_org)
-        collection_fhir_id = self.blaze_service.upload_collection(self.example_collection)
+        self.blaze_service._upload_collection_organization(self.example_collection_org)
+        collection_fhir_id = self.blaze_service._upload_collection(self.example_collection)
         updated = self.blaze_service.add_already_present_samples_to_existing_collection(
             [sample_fhir_id1, new_sample_fhir_id], collection_fhir_id)
         self.assertTrue(updated)
@@ -716,10 +770,11 @@ class TestBlazeService(unittest.TestCase):
         self.assertIn(new_sample_fhir_id, updated_collection.sample_fhir_ids)
 
         self.assertEqual(
-            new_observation.diagnosis_observed_datetime.year - new_donor.date_of_birth.year,
+            new_sample._observations[0].diagnosis_observed_datetime.year - new_donor.date_of_birth.year,
             updated_collection.age_range_high)
         self.assertEqual(
-            self.example_observations[0].diagnosis_observed_datetime.year - self.example_donor.date_of_birth.year,
+            self.example_samples[0]._observations[
+                1].diagnosis_observed_datetime.year - self.example_donor.date_of_birth.year,
             updated_collection.age_range_low)
 
         self.assertIn(self.example_samples[0].storage_temperature, updated_collection.storage_temperatures)
@@ -729,7 +784,7 @@ class TestBlazeService(unittest.TestCase):
         self.assertIn(new_donor.gender, updated_collection.genders)
 
         self.assertIn(self.example_observations[0].icd10_code, updated_collection.diagnoses)
-        self.assertIn(new_observation.icd10_code, updated_collection.diagnoses)
+        self.assertIn(new_sample.diagnoses_icd10_code_with_observed_datetime[0][0], updated_collection.diagnoses)
 
         self.blaze_service.delete_donor(new_donor_fhir_id)
         update_collection = self.blaze_service.update_collection_values(collection_fhir_id)
@@ -740,11 +795,13 @@ class TestBlazeService(unittest.TestCase):
         self.assertEqual(updated_collection.number_of_subjects, 1)
 
         self.assertEqual(
-            self.example_observations[0].diagnosis_observed_datetime.year - self.example_donor.date_of_birth.year,
+            self.example_samples[0]._observations[
+                1].diagnosis_observed_datetime.year - self.example_donor.date_of_birth.year,
             updated_collection.age_range_low)
 
         self.assertEqual(
-            self.example_observations[0].diagnosis_observed_datetime.year - self.example_donor.date_of_birth.year,
+            self.example_samples[0]._observations[
+                0].diagnosis_observed_datetime.year - self.example_donor.date_of_birth.year,
             updated_collection.age_range_high)
 
         self.assertIn(sample_fhir_id1, updated_collection.sample_fhir_ids)
@@ -756,17 +813,18 @@ class TestBlazeService(unittest.TestCase):
         self.assertIn(self.example_donor.gender, updated_collection.genders)
         self.assertNotIn(new_donor.gender, updated_collection.genders)
 
-        self.assertIn(self.example_observations[0].icd10_code, updated_collection.diagnoses)
-        self.assertNotIn(new_observation.icd10_code, updated_collection.diagnoses)
+        self.assertIn(self.example_samples[0].diagnoses_icd10_code_with_observed_datetime[0][0],
+                      updated_collection.diagnoses)
+        self.assertNotIn(new_sample.diagnoses_icd10_code_with_observed_datetime[0][0], updated_collection.diagnoses)
 
     def test_delete_sample_present_in_collection(self):
         self.blaze_service.upload_donor(self.example_donor)
         sample_fhir_id1 = self.blaze_service.upload_sample(self.example_samples[0])
-        self.blaze_service.upload_observation(self.example_observations[0])
-        self.blaze_service.upload_diagnosis_report(self.example_diagnosis_reports[0])
+        self.blaze_service._upload_observation(self.example_observations[0])
+        self.blaze_service._upload_diagnosis_report(self.example_diagnosis_reports[0])
         self.blaze_service.upload_biobank(self.example_biobank)
-        self.blaze_service.upload_collection_organization(self.example_collection_org)
-        collection_fhir_id = self.blaze_service.upload_collection(self.example_collection)
+        self.blaze_service._upload_collection_organization(self.example_collection_org)
+        collection_fhir_id = self.blaze_service._upload_collection(self.example_collection)
         # sample_fhir_id = self.blaze_service.get_fhir_id("Specimen", "sampleId")
         # sample_json = self.blaze_service.get_fhir_resource_as_json("Specimen", sample_fhir_id)
         # sample = Sample.from_json(sample_json, "donorId")

--- a/test/unit/model/test_collection.py
+++ b/test/unit/model/test_collection.py
@@ -2,210 +2,268 @@ import unittest
 
 from fhirclient.models.group import Group
 
-from miabis_model import Collection
+from miabis_model import Collection, _CollectionOrganization
 from miabis_model import Gender
 from miabis_model import StorageTemperature
 
 
 class TestCollection(unittest.TestCase):
     def test_collection_init(self):
-        collection = Collection("collectionId", "collectionName", "collectionOrgId", [Gender.MALE], ["DNA"], 0, 100,
-                                [StorageTemperature.TEMPERATURE_LN])
+        collection = Collection(identifier="collectionId", name="collectionName", managing_biobank_id="biobankId",
+                                contact_name="contactName", contact_surname="contactSurname",
+                                contact_email="contactEmail", country="CZ", genders=[Gender.MALE],
+                                material_types=["Urine"], age_range_low=10, age_range_high=100,
+                                storage_temperatures=[StorageTemperature.TEMPERATURE_LN], diagnoses=["C51"],
+                                number_of_subjects=10, inclusion_criteria=["Sex"], sample_ids=["sampleId"],
+                                alias="collectionAlias", url="urlExample.com", description="description",
+                                dataset_type="LifeStyle", sample_source="Human",
+                                sample_collection_setting="Environment", collection_design=["CaseControl"],
+                                use_and_access_conditions=["CommercialUse"], publications=["publication"])
         self.assertIsInstance(collection, Collection)
         self.assertEqual("collectionId", collection.identifier)
         self.assertEqual("collectionName", collection.name)
-        self.assertEqual("collectionOrgId", collection.managing_collection_org_id)
-        self.assertEqual(0, collection.age_range_low)
-        self.assertEqual(100, collection.age_range_high)
+        self.assertEqual("biobankId", collection.managing_biobank_id)
+        self.assertEqual("collectionId", collection.managing_collection_org_id)
+        self.assertEqual("contactName", collection.contact_name)
+        self.assertEqual("contactSurname", collection.contact_surname)
+        self.assertEqual("contactEmail", collection.contact_email)
+        self.assertEqual("CZ", collection.country)
         self.assertEqual([Gender.MALE], collection.genders)
+        self.assertEqual(["Urine"], collection.material_types)
+        self.assertEqual(10, collection.age_range_low)
+        self.assertEqual(100, collection.age_range_high)
         self.assertEqual([StorageTemperature.TEMPERATURE_LN], collection.storage_temperatures)
-        self.assertEqual(["DNA"], collection.material_types)
+        self.assertEqual(["C51"], collection.diagnoses)
+        self.assertEqual(10, collection.number_of_subjects)
+        self.assertEqual(["Sex"], collection.inclusion_criteria)
+        self.assertEqual(["sampleId"], collection.sample_ids)
+        self.assertEqual("collectionAlias", collection.alias)
+        self.assertEqual("urlExample.com", collection.url)
+        self.assertEqual("description", collection.description)
+        self.assertEqual("LifeStyle", collection.dataset_type)
+        self.assertEqual("Human", collection.sample_source)
+        self.assertEqual("Environment", collection.sample_collection_setting)
+        self.assertEqual(["CaseControl"], collection.collection_design)
+        self.assertEqual(["CommercialUse"], collection.use_and_access_conditions)
+        self.assertEqual(["publication"], collection.publications)
 
     def test_collection_invalid_identifier_type_innit(self):
         with self.assertRaises(TypeError):
-            collection = Collection(37, "collectionName", "collectionOrgId", [Gender.MALE], ["DNA"], 0, 100,
-                                    [StorageTemperature.TEMPERATURE_LN])
+            collection = Collection(identifier=37, name="collectionName", managing_biobank_id="biobankId",
+                                    contact_name="contactName", contact_surname="contactSurname",
+                                    contact_email="contactEmail", country="CZ", genders=[Gender.MALE],
+                                    material_types=["Urine"])
 
     def test_collection_invalid_name_type_innit(self):
         with self.assertRaises(TypeError):
-            collection = Collection("collectionId", 22, "collectionOrgId", [Gender.MALE], ["DNA"], 0, 100,
-                                    [StorageTemperature.TEMPERATURE_LN])
+            collection = Collection(identifier="collectionId", name=37, managing_biobank_id="biobankId",
+                                    contact_name="contactName", contact_surname="contactSurname",
+                                    contact_email="contactEmail", country="CZ", genders=[Gender.MALE],
+                                    material_types=["Urine"])
 
     def test_collection_invalid_managing_biobank_id_type_innit(self):
         with self.assertRaises(TypeError):
-            collection = Collection("collectionId", "collectionName", 22, [Gender.MALE], ["DNA"], 0, 100,
-                                    [StorageTemperature.TEMPERATURE_LN])
+            collection = Collection(identifier="collectionId", name="collectionName", managing_biobank_id=37,
+                                    contact_name="contactName", contact_surname="contactSurname",
+                                    contact_email="contactEmail", country="CZ", genders=[Gender.MALE],
+                                    material_types=["Urine"])
 
     def test_collection_invalid_age_range_low_type_innit(self):
         with self.assertRaises(TypeError):
-            collection = Collection("collectionId", "collectionName", "collectionOrgId", [Gender.MALE], ["DNA"], "0",
-                                    100,
-                                    [StorageTemperature.TEMPERATURE_LN])
+            collection = Collection(identifier="collectionId", name="collectionName", managing_biobank_id="biobankId",
+                                    contact_name="contactName", contact_surname="contactSurname",
+                                    contact_email="contactEmail", country="CZ", genders=[Gender.MALE],
+                                    material_types=["Urine"], age_range_low="Bad")
 
     def test_collection_invalid_age_range_high_type_innit(self):
         with self.assertRaises(TypeError):
-            collection = Collection("collectionId", "collectionName", "collectionOrgId", [Gender.MALE], ["DNA"], 0,
-                                    "100",
-                                    [StorageTemperature.TEMPERATURE_LN])
+            collection = Collection(identifier="collectionId", name="collectionName", managing_biobank_id="biobankId",
+                                    contact_name="contactName", contact_surname="contactSurname",
+                                    contact_email="contactEmail", country="CZ", genders=[Gender.MALE],
+                                    material_types=["Urine"], age_range_high="Bad")
 
     def test_collection_invalid_gender_type_init(self):
         with self.assertRaises(TypeError):
-            collection = Collection("collectionId", "collectionName", "collectionOrgId", "male", ["DNA"], 0, 100,
-                                    [StorageTemperature.TEMPERATURE_LN])
+            collection = Collection(identifier="collectionId", name="collectionName", managing_biobank_id="biobankId",
+                                    contact_name="contactName", contact_surname="contactSurname",
+                                    contact_email="contactEmail", country="CZ", genders="Bad",
+                                    material_types=["Urine"])
 
     def test_collection_invalid_storage_temperature_type_init(self):
         with self.assertRaises(TypeError):
-            collection = Collection("collectionId", "collectionName", "collectionOrgId", [Gender.MALE], ["DNA"], 0, 100,
-                                    "storageTemp")
+            collection = Collection(identifier="collectionId", name="collectionName", managing_biobank_id="biobankId",
+                                    contact_name="contactName", contact_surname="contactSurname",
+                                    contact_email="contactEmail", country="CZ", genders=[Gender.MALE],
+                                    material_types=["Urine"], storage_temperatures="Bad")
 
     def test_collection_invalid_material_type_type_init(self):
         with self.assertRaises(ValueError):
-            collection = Collection("collectionId", "collectionName", "collectionOrgId", [Gender.MALE], [2], 0, 100,
-                                    [StorageTemperature.TEMPERATURE_LN])
+            collection = Collection(identifier="collectionId", name="collectionName", managing_biobank_id="biobankId",
+                                    contact_name="contactName", contact_surname="contactSurname",
+                                    contact_email="contactEmail", country="CZ", genders=[Gender.MALE],
+                                    material_types="Bad")
 
     def test_collection_set_identifier_ok(self):
-        collection = Collection("collectionId", "collectionName", "collectionOrgId", [Gender.MALE], ["DNA"], 0, 100,
-                                [StorageTemperature.TEMPERATURE_LN])
+        collection = Collection(identifier="collectionId", name="collectionName", managing_biobank_id="biobankId",
+                                contact_name="contactName", contact_surname="contactSurname",
+                                contact_email="contactEmail", country="CZ", genders=[Gender.MALE],
+                                material_types=["Urine"])
         collection.identifier = "newId"
         self.assertEqual("newId", collection.identifier)
 
     def test_collection_set_identifier_invalid(self):
-        collection = Collection("collectionId", "collectionName", "collectionOrgId", [Gender.MALE], ["DNA"], 0, 100,
-                                [StorageTemperature.TEMPERATURE_LN])
+        collection = Collection(identifier="collectionId", name="collectionName", managing_biobank_id="biobankId",
+                                contact_name="contactName", contact_surname="contactSurname",
+                                contact_email="contactEmail", country="CZ", genders=[Gender.MALE],
+                                material_types=["Urine"])
         with self.assertRaises(TypeError):
             collection.identifier = 37
 
     def test_collection_set_name_ok(self):
-        collection = Collection("collectionId", "collectionName", "collectionOrgId", [Gender.MALE], ["DNA"], 0, 100,
-                                [StorageTemperature.TEMPERATURE_LN])
+        collection = Collection(identifier="collectionId", name="collectionName", managing_biobank_id="biobankId",
+                                contact_name="contactName", contact_surname="contactSurname",
+                                contact_email="contactEmail", country="CZ", genders=[Gender.MALE],
+                                material_types=["Urine"])
         collection.name = "newName"
         self.assertEqual("newName", collection.name)
 
     def test_collection_set_name_invalid(self):
-        collection = Collection("collectionId", "collectionName", "collectionOrgId", [Gender.MALE], ["DNA"], 0, 100,
-                                [StorageTemperature.TEMPERATURE_LN])
+        collection = Collection(identifier="collectionId", name="collectionName", managing_biobank_id="biobankId",
+                                contact_name="contactName", contact_surname="contactSurname",
+                                contact_email="contactEmail", country="CZ", genders=[Gender.MALE],
+                                material_types=["Urine"])
         with self.assertRaises(TypeError):
             collection.name = 37
 
-    def test_collection_set_managing_biobank_id_ok(self):
-        collection = Collection("collectionId", "collectionName", "collectionOrgId", [Gender.MALE], ["DNA"], 0, 100,
-                                [StorageTemperature.TEMPERATURE_LN])
-        collection.managing_biobank_id = "newBiobankId"
-        self.assertEqual("newBiobankId", collection.managing_biobank_id)
+    def test_collection_set_managing_collection_org_id_ok(self):
+        collection = Collection(identifier="collectionId", name="collectionName", managing_biobank_id="biobankId",
+                                contact_name="contactName", contact_surname="contactSurname",
+                                contact_email="contactEmail", country="CZ", genders=[Gender.MALE],
+                                material_types=["Urine"])
+        collection.managing_collection_org_id = "newBiobankId"
+        self.assertEqual("newBiobankId", collection.managing_collection_org_id)
 
     def test_collection_set_managing_biobank_id_invalid(self):
-        collection = Collection("collectionId", "collectionName", "collectionOrgId", [Gender.MALE], ["DNA"], 0, 100,
-                                [StorageTemperature.TEMPERATURE_LN])
+        collection = Collection(identifier="collectionId", name="collectionName", managing_biobank_id="biobankId",
+                                contact_name="contactName", contact_surname="contactSurname",
+                                contact_email="contactEmail", country="CZ", genders=[Gender.MALE],
+                                material_types=["Urine"])
         with self.assertRaises(TypeError):
             collection.managing_collection_org_id = 37
 
     def test_collection_set_age_range_low_ok(self):
-        collection = Collection("collectionId", "collectionName", "collectionOrgId", [Gender.MALE], ["DNA"], 0, 100,
-                                [StorageTemperature.TEMPERATURE_LN])
+        collection = Collection(identifier="collectionId", name="collectionName", managing_biobank_id="biobankId",
+                                contact_name="contactName", contact_surname="contactSurname",
+                                contact_email="contactEmail", country="CZ", genders=[Gender.MALE],
+                                material_types=["Urine"])
         collection.age_range_low = 10
         self.assertEqual(10, collection.age_range_low)
 
     def test_collection_set_age_range_low_invalid(self):
-        collection = Collection("collectionId", "collectionName", "collectionOrgId", [Gender.MALE], ["DNA"], 0, 100,
-                                [StorageTemperature.TEMPERATURE_LN])
+        collection = Collection(identifier="collectionId", name="collectionName", managing_biobank_id="biobankId",
+                                contact_name="contactName", contact_surname="contactSurname",
+                                contact_email="contactEmail", country="CZ", genders=[Gender.MALE],
+                                material_types=["Urine"])
         with self.assertRaises(TypeError):
             collection.age_range_low = "10"
 
     def test_collection_set_age_range_high_ok(self):
-        collection = Collection("collectionId", "collectionName", "collectionOrgId", [Gender.MALE], ["DNA"], 0, 100,
-                                [StorageTemperature.TEMPERATURE_LN])
+        collection = Collection(identifier="collectionId", name="collectionName", managing_biobank_id="biobankId",
+                                contact_name="contactName", contact_surname="contactSurname",
+                                contact_email="contactEmail", country="CZ", genders=[Gender.MALE],
+                                material_types=["Urine"])
         collection.age_range_high = 10
         self.assertEqual(10, collection.age_range_high)
 
     def test_collection_set_age_range_high_invalid(self):
-        collection = Collection("collectionId", "collectionName", "collectionOrgId", [Gender.MALE], ["DNA"], 0, 100,
-                                [StorageTemperature.TEMPERATURE_LN])
+        collection = Collection(identifier="collectionId", name="collectionName", managing_biobank_id="biobankId",
+                                contact_name="contactName", contact_surname="contactSurname",
+                                contact_email="contactEmail", country="CZ", genders=[Gender.MALE],
+                                material_types=["Urine"])
         with self.assertRaises(TypeError):
             collection.age_range_high = "10"
 
     def test_collection_set_gender_ok(self):
-        collection = Collection("collectionId", "collectionName", "collectionOrgId", [Gender.MALE], ["DNA"], 0, 100,
-                                [StorageTemperature.TEMPERATURE_LN])
+        collection = Collection(identifier="collectionId", name="collectionName", managing_biobank_id="biobankId",
+                                contact_name="contactName", contact_surname="contactSurname",
+                                contact_email="contactEmail", country="CZ", genders=[Gender.MALE],
+                                material_types=["Urine"])
         collection.genders = [Gender.FEMALE]
         self.assertEqual([Gender.FEMALE], collection.genders)
 
     def test_collection_set_gender_invalid(self):
-        collection = Collection("collectionId", "collectionName", "collectionOrgId", [Gender.MALE], ["DNA"], 0, 100,
-                                [StorageTemperature.TEMPERATURE_LN])
+        collection = Collection(identifier="collectionId", name="collectionName", managing_biobank_id="biobankId",
+                                contact_name="contactName", contact_surname="contactSurname",
+                                contact_email="contactEmail", country="CZ", genders=[Gender.MALE],
+                                material_types=["Urine"])
         with self.assertRaises(TypeError):
             collection.genders = [37]
 
     def test_collection_set_storage_temperature_ok(self):
-        collection = Collection("collectionId", "collectionName", "collectionOrgId", [Gender.MALE], ["DNA"], 0, 100,
-                                [StorageTemperature.TEMPERATURE_LN])
+        collection = Collection(identifier="collectionId", name="collectionName", managing_biobank_id="biobankId",
+                                contact_name="contactName", contact_surname="contactSurname",
+                                contact_email="contactEmail", country="CZ", genders=[Gender.MALE],
+                                material_types=["Urine"])
         collection.storage_temperatures = [StorageTemperature.TEMPERATURE_LN]
         self.assertEqual([StorageTemperature.TEMPERATURE_LN], collection.storage_temperatures)
 
     def test_collection_set_storage_temperature_invalid(self):
-        collection = Collection("collectionId", "collectionName", "collectionOrgId", [Gender.MALE], ["DNA"], 0, 100,
-                                [StorageTemperature.TEMPERATURE_LN])
+        collection = Collection(identifier="collectionId", name="collectionName", managing_biobank_id="biobankId",
+                                contact_name="contactName", contact_surname="contactSurname",
+                                contact_email="contactEmail", country="CZ", genders=[Gender.MALE],
+                                material_types=["Urine"])
         with self.assertRaises(TypeError):
             collection.storage_temperatures = [37]
 
     def test_collection_set_material_type_ok(self):
-        collection = Collection("collectionId", "collectionName", "collectionOrgId", [Gender.MALE], ["DNA"], 0, 100,
-                                [StorageTemperature.TEMPERATURE_LN])
+        collection = Collection(identifier="collectionId", name="collectionName", managing_biobank_id="biobankId",
+                                contact_name="contactName", contact_surname="contactSurname",
+                                contact_email="contactEmail", country="CZ", genders=[Gender.MALE],
+                                material_types=["Urine"])
         collection.material_types = ["RNA"]
         self.assertEqual(["RNA"], collection.material_types)
 
     def test_collection_set_material_type_invalid(self):
-        collection = Collection("collectionId", "collectionName", "collectionOrgId", [Gender.MALE], ["DNA"], 0, 100,
-                                [StorageTemperature.TEMPERATURE_LN])
+        collection = Collection(identifier="collectionId", name="collectionName", managing_biobank_id="biobankId",
+                                contact_name="contactName", contact_surname="contactSurname",
+                                contact_email="contactEmail", country="CZ", genders=[Gender.MALE],
+                                material_types=["Urine"])
         with self.assertRaises(ValueError):
             collection.material_types = [37]
 
     def test_collection_optional_args_description_invalid(self):
         with self.assertRaises(TypeError):
-            collection = Collection("collectionId", "collectionName", "collectionOrgId", [Gender.MALE], ["DNA"], 0, 100,
-                                    [StorageTemperature.TEMPERATURE_LN],
-                                    description=37)
-
-    def test_collection_optional_args_diagnosis(self):
-        collection = Collection("collectionId", "collectionName", "collectionOrgId", [Gender.MALE], ["DNA"], 0, 100,
-                                [StorageTemperature.TEMPERATURE_LN], diagnoses=["C51"], number_of_subjects=10,
-                                inclusion_criteria=["Sex"], sample_ids=["samID1", "samID2"])
-        self.assertEqual(["C51"], collection.diagnoses)
-        self.assertEqual(10, collection.number_of_subjects)
-        self.assertEqual(["Sex"], collection.inclusion_criteria)
-        self.assertEqual(["samID1", "samID2"], collection.sample_ids)
+            collection = Collection(identifier="collectionId", name="collectionName", managing_biobank_id="biobankId",
+                                    contact_name="contactName", contact_surname="contactSurname",
+                                    contact_email="contactEmail", country="CZ", genders=[Gender.MALE],
+                                    material_types=["Urine"], description=32)
 
     def test_collection_optional_args_diagnosis_invalid(self):
         with self.assertRaises(ValueError):
-            collection = Collection("collectionId", "collectionName", "collectionOrgId", [Gender.MALE], ["DNA"], 0, 100,
-                                    [StorageTemperature.TEMPERATURE_LN],
-                                    diagnoses=["C11111"])
-
-    def test_collection_optional_args_inclusion_criteria(self):
-        collection = Collection("collectionId", "collectionName", "collectionOrgId", [Gender.MALE], ["DNA"], 0, 100,
-                                [StorageTemperature.TEMPERATURE_LN],
-                                inclusion_criteria=["HealthStatus"])
-        self.assertEqual(["HealthStatus"], collection.inclusion_criteria)
+            collection = Collection(identifier="collectionId", name="collectionName", managing_biobank_id="biobankId",
+                                    contact_name="contactName", contact_surname="contactSurname",
+                                    contact_email="contactEmail", country="CZ", genders=[Gender.MALE],
+                                    material_types=["Urine"], diagnoses=["C333333"])
 
     def test_collection_optional_args_inclusion_criteria_invalid(self):
-        with self.assertRaises(ValueError):
-            collection = Collection("collectionId", "collectionName", "collectionOrgId", [Gender.MALE], ["DNA"], 0, 100,
-                                    [StorageTemperature.TEMPERATURE_LN],
-                                    inclusion_criteria=["Invalid"])
-
-    def test_collection_optional_args_number_of_subject(self):
-        collection = Collection("collectionId", "collectionName", "collectionOrgId", [Gender.MALE], ["DNA"], 0, 100,
-                                [StorageTemperature.TEMPERATURE_LN],
-                                number_of_subjects=10)
-        self.assertEqual(10, collection.number_of_subjects)
+        with self.assertRaises(TypeError):
+            collection = Collection(identifier="collectionId", name="collectionName", managing_biobank_id="biobankId",
+                                    contact_name="contactName", contact_surname="contactSurname",
+                                    contact_email="contactEmail", country="CZ", genders=[Gender.MALE],
+                                    material_types=["Urine"], inclusion_criteria="Invalid")
 
     def test_collection_optional_args_number_of_subject_invalid(self):
         with self.assertRaises(TypeError):
-            collection = Collection("collectionId", "collectionName", "collectionOrgId", [Gender.MALE], ["DNA"], 0, 100,
-                                    [StorageTemperature.TEMPERATURE_LN],
-                                    number_of_subjects="10")
+            collection = Collection(identifier="collectionId", name="collectionName", managing_biobank_id="biobankId",
+                                    contact_name="contactName", contact_surname="contactSurname",
+                                    contact_email="contactEmail", country="CZ", genders=[Gender.MALE],
+                                    material_types=["Urine"], number_of_subjects="invalid")
 
     def test_collection_required_args_to_fhir(self):
-        collection = Collection("collectionId", "collectionName", "collectionOrgId", [Gender.MALE], ["DNA"])
+        collection = Collection(identifier="collectionId", name="collectionName", managing_biobank_id="biobankId",
+                                contact_name="contactName", contact_surname="contactSurname",
+                                contact_email="contactEmail", country="CZ", genders=[Gender.MALE],
+                                material_types=["Urine"])
         collection_fhir = collection.to_fhir("biobankFhirId", ["sampleFhirId1", "sampleFhirId2"])
         self.assertIsInstance(collection_fhir, Group)
         self.assertEqual(collection.identifier, collection_fhir.identifier[0].value)
@@ -219,10 +277,14 @@ class TestCollection(unittest.TestCase):
         self.assertEqual(collection_fhir.extension[1].valueReference.reference, "Specimen/sampleFhirId2")
 
     def test_collection_optional_args_to_fhir(self):
-        collection = Collection("collectionId", "collectionName", "managingBiobankId", [Gender.MALE], ["DNA"], 0, 100,
-                                storage_temperatures=[StorageTemperature.TEMPERATURE_LN], diagnoses=["C51"],
-                                inclusion_criteria=["HealthStatus"], number_of_subjects=10
-                                )
+        collection = Collection(identifier="collectionId", name="collectionName",
+                                managing_biobank_id="managingBiobankId",
+                                contact_name="contactName", contact_surname="contactSurname",
+                                contact_email="contactEmail", country="CZ", genders=[Gender.MALE],
+                                material_types=["DNA"], age_range_low=0, age_range_high=100, diagnoses=["C51"],
+                                inclusion_criteria=["HealthStatus"], number_of_subjects=10,
+                                storage_temperatures=[StorageTemperature.TEMPERATURE_LN])
+
         collection_fhir = collection.to_fhir("biobankFhirId", ["sampleFhirId1", "sampleFhirId2"])
         self.assertIsInstance(collection_fhir, Group)
         self.assertEqual(collection.identifier, collection_fhir.identifier[0].value)
@@ -244,15 +306,21 @@ class TestCollection(unittest.TestCase):
         self.assertEqual(collection_fhir.extension[3].valueReference.reference, "Specimen/sampleFhirId2")
 
     def test_collection_from_json(self):
-        example_collection = Collection("collectionId", "collectionName", "managingBiobankId", [Gender.MALE], ["DNA"],
-                                        0, 100,
-                                        storage_temperatures=[StorageTemperature.TEMPERATURE_LN], diagnoses=["C51"],
+        example_collection = Collection(identifier="collectionId", name="collectionName",
+                                        managing_biobank_id="managingBiobankId",
+                                        contact_name="contactName", contact_surname="contactSurname",
+                                        contact_email="contactEmail", country="CZ", genders=[Gender.MALE],
+                                        material_types=["DNA"], age_range_low=0, age_range_high=100, diagnoses=["C51"],
                                         inclusion_criteria=["HealthStatus"], number_of_subjects=10,
-                                        sample_ids=["sampleId1", "sampleId2"]
-                                        )
-        example_collection_fhir = example_collection.to_fhir("biobankFHIRId", ["sampleFHIRId1", "sampleFHIRId2"])
+                                        storage_temperatures=[StorageTemperature.TEMPERATURE_LN],
+                                        sample_ids=["sampleId1", "sampleId2"])
+        collection_org = example_collection._collection_org
+        collection_org_fhir = collection_org.to_fhir("biobankFHIRId")
+        collection_org_fhir.id = "TestOrgFHIRId"
+        collection_org_json = collection_org_fhir.as_json()
+        example_collection_fhir = example_collection.to_fhir("TestOrgFHIRId", ["sampleFHIRId1", "sampleFHIRId2"])
         example_collection_fhir.id = "TestFHIRId"
-        collection = Collection.from_json(example_collection_fhir.as_json(), "managingBiobankId",
+        collection = Collection.from_json(example_collection_fhir.as_json(), collection_org_json, "managingBiobankId",
                                           ["sampleId1", "sampleId2"])
         self.assertIsInstance(collection, Collection)
         self.assertEqual(example_collection.identifier, collection.identifier)
@@ -268,14 +336,23 @@ class TestCollection(unittest.TestCase):
         self.assertEqual(example_collection.number_of_subjects, collection.number_of_subjects)
         self.assertEqual(example_collection.sample_ids, collection.sample_ids)
         self.assertEqual("TestFHIRId", collection.collection_fhir_id)
-        self.assertEqual("biobankFHIRId", collection.managing_collection_org_fhir_id)
+        self.assertEqual("TestOrgFHIRId", collection.managing_collection_org_fhir_id)
         self.assertEqual(["sampleFHIRId1", "sampleFHIRId2"], collection.sample_fhir_ids)
+        self.assertEqual(example_collection.contact_name, collection.contact_name)
+        self.assertEqual(example_collection.contact_email, collection.contact_email)
+        self.assertEqual(example_collection.contact_surname, collection.contact_surname)
+        self.assertEqual(example_collection.country, collection.country)
+        self.assertEqual("TestOrgFHIRId", collection._collection_org._collection_org_fhir_id)
+        self.assertEqual("biobankFHIRId", collection._collection_org._managing_biobank_fhir_id)
 
     def test_collection_to_fhir_empty_characteristics(self):
-        collection = Collection("collectionId", "collectionName", "managingBiobankId", [], [], 0, 100,
-                                [], diagnoses=[],
+        collection = Collection(identifier="collectionId", name="collectionName",
+                                managing_biobank_id="managingBiobankId",
+                                contact_name="contactName", contact_surname="contactSurname",
+                                contact_email="contactEmail", country="CZ", genders=[],
+                                material_types=[], age_range_low=0, age_range_high=100, diagnoses=[],
                                 inclusion_criteria=["HealthStatus"], number_of_subjects=10,
-                                )
+                                storage_temperatures=[])
         collection_fhir = collection.to_fhir("biobankFhirId", ["sampleFhirId1", "sampleFhirId2"])
         self.assertIsInstance(collection_fhir, Group)
         self.assertEqual(collection.identifier, collection_fhir.identifier[0].value)

--- a/test/unit/model/test_collection_org.py
+++ b/test/unit/model/test_collection_org.py
@@ -1,14 +1,14 @@
 import unittest
 
-from miabis_model.collection_organization import CollectionOrganization
+from miabis_model.collection import _CollectionOrganization
 
 
 class TestCollectionOrganization(unittest.TestCase):
 
     def test_collection_org_init_required_params(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz")
-        self.assertIsInstance(collection_org, CollectionOrganization)
+        self.assertIsInstance(collection_org, _CollectionOrganization)
         self.assertEqual("collectionOrgId", collection_org.identifier)
         self.assertEqual("collectionOrgName", collection_org.name)
         self.assertEqual("biobankId", collection_org.managing_biobank_id)
@@ -18,12 +18,12 @@ class TestCollectionOrganization(unittest.TestCase):
         self.assertEqual("cz", collection_org.country)
 
     def test_collection_org_init_optional_params(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz", "alias", "url",
                                                 "description",
                                                 "LifeStyle", "Human", "Environment", ["CaseControl"],
-                                                ["CommercialUse"], ["publication"])
-        self.assertIsInstance(collection_org, CollectionOrganization)
+                                                 ["CommercialUse"], ["publication"])
+        self.assertIsInstance(collection_org, _CollectionOrganization)
         self.assertEqual("collectionOrgId", collection_org.identifier)
         self.assertEqual("collectionOrgName", collection_org.name)
         self.assertEqual("biobankId", collection_org.managing_biobank_id)
@@ -43,298 +43,298 @@ class TestCollectionOrganization(unittest.TestCase):
 
     def test_collection_org_invalid_identifier_type_innit(self):
         with self.assertRaises(TypeError):
-            collection_org = CollectionOrganization(37, "collectionOrgName", "biobankId", "contactName",
+            collection_org = _CollectionOrganization(37, "collectionOrgName", "biobankId", "contactName",
                                                     "contactSurname", "contactEmail", "cz")
 
     def test_collection_org_invalid_name_type_innit(self):
         with self.assertRaises(TypeError):
-            collection_org = CollectionOrganization("collectionOrgId", 22, "biobankId", "contactName",
+            collection_org = _CollectionOrganization("collectionOrgId", 22, "biobankId", "contactName",
                                                     "contactSurname", "contactEmail", "cz")
 
     def test_collection_org_invalid_managing_biobank_id_type_innit(self):
         with self.assertRaises(TypeError):
-            collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", 22, "contactName",
+            collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", 22, "contactName",
                                                     "contactSurname", "contactEmail", "cz")
 
     def test_collection_org_invalid_contact_name_type_innit(self):
         with self.assertRaises(TypeError):
-            collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", 22,
+            collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", 22,
                                                     "contactSurname", "contactEmail", "cz")
 
     def test_collection_org_invalid_contact_surname_type_innit(self):
         with self.assertRaises(TypeError):
-            collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
+            collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
                                                     "contactName",
-                                                    22, "contactEmail", "cz")
+                                                     22, "contactEmail", "cz")
 
     def test_collection_org_invalid_contact_email_type_innit(self):
         with self.assertRaises(TypeError):
-            collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
+            collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
                                                     "contactName",
                                                     "contactSurname", 22, "cz")
 
     def test_collection_org_invalid_country_type_innit(self):
         with self.assertRaises(TypeError):
-            collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
+            collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
                                                     "contactName",
                                                     "contactSurname", "contactEmail", 22)
 
     def test_collection_org_invalid_alias_type_innit(self):
         with self.assertRaises(TypeError):
-            collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
+            collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
                                                     "contactName",
                                                     "contactSurname", "contactEmail", "cz", 22)
 
     def test_collection_org_invalid_url_type_innit(self):
         with self.assertRaises(TypeError):
-            collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
+            collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
                                                     "contactName",
                                                     "contactSurname", "contactEmail", "cz", url=22)
 
     def test_collection_org_invalid_description_type_innit(self):
         with self.assertRaises(TypeError):
-            collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
+            collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
                                                     "contactName",
                                                     "contactSurname", "contactEmail", "cz", description=22)
 
     def test_collection_org_invalid_dataset_type_type_innit(self):
         with self.assertRaises(ValueError):
-            collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
+            collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
                                                     "contactName",
                                                     "contactSurname", "contactEmail", "cz", dataset_type=22)
 
     def test_collection_org_invalid_sample_source_type_innit(self):
         with self.assertRaises(ValueError):
-            collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
+            collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
                                                     "contactName",
                                                     "contactSurname", "contactEmail", "cz", sample_source=22)
 
     def test_collection_org_invalid_sample_collection_setting_type_innit(self):
         with self.assertRaises(ValueError):
-            collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
+            collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
                                                     "contactName",
                                                     "contactSurname", "contactEmail", "cz",
-                                                    sample_collection_setting=22)
+                                                     sample_collection_setting=22)
 
     def test_collection_org_invalid_collection_design_type_innit(self):
         with self.assertRaises(TypeError):
-            collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
+            collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
                                                     "contactName",
                                                     "contactSurname", "contactEmail", "cz", collection_design=22)
 
     def test_collection_org_invalid_use_and_access_conditions_type_innit(self):
         with self.assertRaises(TypeError):
-            collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
+            collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
                                                     "contactName",
                                                     "contactSurname", "contactEmail", "cz",
-                                                    use_and_access_conditions=22)
+                                                     use_and_access_conditions=22)
 
     def test_collection_org_invalid_publications_type_innit(self):
         with self.assertRaises(TypeError):
-            collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
+            collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
                                                     "contactName",
                                                     "contactSurname", "contactEmail", "cz", publications=22)
 
     def test_collection_org_set_identifier_ok(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz")
         collection_org.identifier = "newId"
         self.assertEqual("newId", collection_org.identifier)
 
     def test_collection_org_set_identifier_invalid(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz")
         with self.assertRaises(TypeError):
             collection_org.identifier = 37
 
     def test_collection_org_set_name_ok(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz")
         collection_org.name = "newName"
         self.assertEqual("newName", collection_org.name)
 
     def test_collection_org_set_name_invalid(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz")
         with self.assertRaises(TypeError):
             collection_org.name = 37
 
     def test_collection_org_set_managing_biobank_id_ok(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz")
         collection_org.managing_biobank_id = "newId"
         self.assertEqual("newId", collection_org.managing_biobank_id)
 
     def test_collection_org_set_managing_biobank_id_invalid(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz")
         with self.assertRaises(TypeError):
             collection_org.managing_biobank_id = 37
 
     def test_collection_org_set_contact_name_ok(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz")
         collection_org.contact_name = "newName"
         self.assertEqual("newName", collection_org.contact_name)
 
     def test_collection_org_set_contact_name_invalid(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz")
         with self.assertRaises(TypeError):
             collection_org.contact_name = 37
 
     def test_collection_org_set_contact_surname_ok(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz")
         collection_org.contact_surname = "newName"
         self.assertEqual("newName", collection_org.contact_surname)
 
     def test_collection_org_set_contact_surname_invalid(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz")
         with self.assertRaises(TypeError):
             collection_org.contact_surname = 37
 
     def test_collection_org_set_contact_email_ok(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz")
         collection_org.contact_email = "newName"
         self.assertEqual("newName", collection_org.contact_email)
 
     def test_collection_org_set_contact_email_invalid(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz")
         with self.assertRaises(TypeError):
             collection_org.contact_email = 37
 
     def test_collection_org_set_country_ok(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz")
         collection_org.country = "newName"
         self.assertEqual("newName", collection_org.country)
 
     def test_collection_org_set_country_invalid(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz")
         with self.assertRaises(TypeError):
             collection_org.country = 37
 
     def test_collection_org_set_alias_ok(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz", "alias")
         collection_org.alias = "newName"
         self.assertEqual("newName", collection_org.alias)
 
     def test_collection_org_set_alias_invalid(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz", "alias")
         with self.assertRaises(TypeError):
             collection_org.alias = 37
 
     def test_collection_org_set_url_ok(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz", url="url")
         collection_org.url = "newName"
         self.assertEqual("newName", collection_org.url)
 
     def test_collection_org_set_url_invalid(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz", url="url")
         with self.assertRaises(TypeError):
             collection_org.url = 37
 
     def test_collection_org_set_description_ok(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz", description="description")
         collection_org.description = "newName"
         self.assertEqual("newName", collection_org.description)
 
     def test_collection_org_set_description_invalid(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz", description="description")
         with self.assertRaises(TypeError):
             collection_org.description = 37
 
     def test_collection_org_set_dataset_type_ok(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz", dataset_type="LifeStyle")
         collection_org.dataset_type = "Environmental"
         self.assertEqual("Environmental", collection_org.dataset_type)
 
     def test_collection_org_set_dataset_type_invalid(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz", dataset_type="LifeStyle")
         with self.assertRaises(ValueError):
             collection_org.dataset_type = 37
 
     def test_collection_org_set_sample_source_ok(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz", sample_source="Human")
         collection_org.sample_source = "Environment"
         self.assertEqual("Environment", collection_org.sample_source)
 
     def test_collection_org_set_sample_source_invalid(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz", sample_source="Human")
         with self.assertRaises(ValueError):
             collection_org.sample_source = "Invalid"
 
     def test_collection_org_set_sample_collection_setting_ok(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz",
-                                                sample_collection_setting="Environment")
+                                                 sample_collection_setting="Environment")
         collection_org.sample_collection_setting = "Unknown"
         self.assertEqual("Unknown", collection_org.sample_collection_setting)
 
     def test_collection_org_set_sample_collection_setting_invalid(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz",
-                                                sample_collection_setting="Environment")
+                                                 sample_collection_setting="Environment")
         with self.assertRaises(ValueError):
             collection_org.sample_collection_setting = "Invalid"
 
     def test_collection_org_set_collection_design_ok(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz",
-                                                collection_design=["CaseControl"])
+                                                 collection_design=["CaseControl"])
         collection_org.collection_design = ["CrossSectional"]
         self.assertEqual(["CrossSectional"], collection_org.collection_design)
 
     def test_collection_org_set_collection_design_invalid(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz",
-                                                collection_design=["CaseControl"])
+                                                 collection_design=["CaseControl"])
         with self.assertRaises(ValueError):
             collection_org.collection_design = ["Invalid"]
 
     def test_collection_org_set_use_and_access_conditions_ok(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz",
-                                                use_and_access_conditions=["CommercialUse"])
+                                                 use_and_access_conditions=["CommercialUse"])
         collection_org.use_and_access_conditions = ["Xenograft"]
         self.assertEqual(["Xenograft"], collection_org.use_and_access_conditions)
 
     def test_collection_org_set_use_and_access_conditions_invalid(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz",
-                                                use_and_access_conditions=["CommercialUse"])
+                                                 use_and_access_conditions=["CommercialUse"])
         with self.assertRaises(ValueError):
             collection_org.use_and_access_conditions = ["Invalid"]
 
     def test_collection_org_set_publications_ok(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz", publications=["publication"])
         collection_org.publications = ["publication2"]
         self.assertEqual(["publication2"], collection_org.publications)
 
     def test_collection_org_set_publications_invalid(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz", publications=["publication"])
         with self.assertRaises(TypeError):
             collection_org.publications = 37
 
     def test_collection_org_to_fhir_required_params_ok(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz")
         collection_org_fhir = collection_org.to_fhir("biobankFhirId")
         self.assertEqual("collectionOrgId", collection_org_fhir.identifier[0].value)
@@ -348,11 +348,11 @@ class TestCollectionOrganization(unittest.TestCase):
         self.assertEqual("cz", collection_org_fhir.address[0].country)
 
     def test_collection_org_to_fhir_optional_params_ok(self):
-        collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
+        collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId", "contactName",
                                                 "contactSurname", "contactEmail", "cz", "alias", "url",
                                                 "description",
                                                 "LifeStyle", "Human", "Environment", ["CaseControl"],
-                                                ["CommercialUse"], ["publication"])
+                                                 ["CommercialUse"], ["publication"])
         collection_org_fhir = collection_org.to_fhir("biobankFhirId")
         self.assertEqual("alias", collection_org_fhir.alias[0])
         self.assertEqual("url", collection_org_fhir.telecom[0].value)
@@ -365,16 +365,16 @@ class TestCollectionOrganization(unittest.TestCase):
         self.assertEqual("description", collection_org_fhir.extension[6].valueString)
 
     def test_collection_org_from_json(self):
-        example_collection_org = CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
+        example_collection_org = _CollectionOrganization("collectionOrgId", "collectionOrgName", "biobankId",
                                                         "contactName",
                                                         "contactSurname", "contactEmail", "cz", "alias", "url",
                                                         "description",
                                                         "LifeStyle", "Human", "Environment", ["CaseControl"],
-                                                        ["CommercialUse"], ["publication"])
+                                                         ["CommercialUse"], ["publication"])
         example_fhir = example_collection_org.to_fhir("biobankFHIRId")
         example_fhir.id = "TestFHIRId"
-        collection_org = CollectionOrganization.from_json(example_fhir.as_json(), "biobankId")
-        self.assertIsInstance(collection_org, CollectionOrganization)
+        collection_org = _CollectionOrganization.from_json(example_fhir.as_json(), "biobankId")
+        self.assertIsInstance(collection_org, _CollectionOrganization)
         self.assertEqual(example_collection_org.identifier, collection_org.identifier)
         self.assertEqual(example_collection_org.name, collection_org.name)
         self.assertEqual(example_collection_org.managing_biobank_id, collection_org.managing_biobank_id)

--- a/test/unit/model/test_condition.py
+++ b/test/unit/model/test_condition.py
@@ -59,7 +59,7 @@ class TestCondition(unittest.TestCase):
         example_condition = Condition("donorId", "C51")
         example_fhir = example_condition.to_fhir("donorFHIRId", ["drFHIRId1", "drFHIRId2"])
         example_fhir.id = "TestFHIRId"
-        condition = Condition.from_json(example_fhir.as_json(),"donorId")
+        condition = Condition.from_json(example_fhir.as_json(), "donorId")
         self.assertEqual("TestFHIRId", condition.condition_fhir_id)
         self.assertEqual("donorFHIRId", condition.patient_fhir_id)
         self.assertEqual(example_condition.patient_identifier, condition.patient_identifier)

--- a/test/unit/model/test_diagnosis_report.py
+++ b/test/unit/model/test_diagnosis_report.py
@@ -1,18 +1,18 @@
 import unittest
 
-from miabis_model import DiagnosisReport
+from miabis_model import _DiagnosisReport
 
 
 class TestDiagnosisReport(unittest.TestCase):
     def test_diagnosis_report_init(self):
-        diagnosis_report = DiagnosisReport("sampleId", "donorId")
-        self.assertIsInstance(diagnosis_report, DiagnosisReport)
+        diagnosis_report = _DiagnosisReport("sampleId", "donorId")
+        self.assertIsInstance(diagnosis_report, _DiagnosisReport)
         self.assertEqual("sampleId", diagnosis_report.sample_identifier)
         self.assertEqual("donorId", diagnosis_report.patient_identifier)
 
     def test_diagnosis_report_init_optional_params(self):
-        diagnosis_report = DiagnosisReport("sampleId", "donorId", ["obsId"], "diagId")
-        self.assertIsInstance(diagnosis_report, DiagnosisReport)
+        diagnosis_report = _DiagnosisReport("sampleId", "donorId", ["obsId"], "diagId")
+        self.assertIsInstance(diagnosis_report, _DiagnosisReport)
         self.assertEqual("sampleId", diagnosis_report.sample_identifier)
         self.assertEqual("donorId", diagnosis_report.patient_identifier)
         self.assertEqual(["obsId"], diagnosis_report.observations_identifiers)
@@ -20,34 +20,34 @@ class TestDiagnosisReport(unittest.TestCase):
 
     def test_diagnosis_report_invalid_sample_identifier_type_innit(self):
         with self.assertRaises(TypeError):
-            DiagnosisReport(37, "donorId")
+            _DiagnosisReport(37, "donorId")
 
     def test_diagnosis_report_invalid_patient_identifier_type_innit(self):
         with self.assertRaises(TypeError):
-            DiagnosisReport("sampleId", 37)
+            _DiagnosisReport("sampleId", 37)
 
     def test_diagnosis_report_set_sample_identifier_ok(self):
-        diagnosis_report = DiagnosisReport("sampleId", "donorId")
+        diagnosis_report = _DiagnosisReport("sampleId", "donorId")
         diagnosis_report.sample_identifier = "newId"
         self.assertEqual("newId", diagnosis_report.sample_identifier)
 
     def test_diagnosis_report_set_sample_identifier_invalid(self):
-        diagnosis_report = DiagnosisReport("sampleId", "donorId")
+        diagnosis_report = _DiagnosisReport("sampleId", "donorId")
         with self.assertRaises(TypeError):
             diagnosis_report.sample_identifier = 37
 
     def test_diagnosis_report_set_patient_identifier_ok(self):
-        diagnosis_report = DiagnosisReport("sampleId", "donorId")
+        diagnosis_report = _DiagnosisReport("sampleId", "donorId")
         diagnosis_report.patient_identifier = "newDonorId"
         self.assertEqual("newDonorId", diagnosis_report.patient_identifier)
 
     def test_diagnosis_report_set_patient_identifier_invalid(self):
-        diagnosis_report = DiagnosisReport("sampleId", "donorId")
+        diagnosis_report = _DiagnosisReport("sampleId", "donorId")
         with self.assertRaises(TypeError):
             diagnosis_report.observations_identifiers = 37
 
     def test_diagnosis_report_to_fhir_ok(self):
-        diagnosis_report = DiagnosisReport("sampleId", "donorId", diagnosis_report_identifier="diagnosisReportId")
+        diagnosis_report = _DiagnosisReport("sampleId", "donorId", diagnosis_report_identifier="diagnosisReportId")
         diagnosis_report_fhir = diagnosis_report.to_fhir("sampleFhirId", "donorFhirId", ["obsFhirId"])
         self.assertEqual("diagnosisReportId", diagnosis_report_fhir.identifier[0].value)
         self.assertEqual("Observation/obsFhirId", diagnosis_report_fhir.result[0].reference)
@@ -56,12 +56,12 @@ class TestDiagnosisReport(unittest.TestCase):
         self.assertEqual("final", diagnosis_report_fhir.status)
 
     def test_diagnosis_report_multiple_observations_ok(self):
-        diagnosis_report = DiagnosisReport("sampleId", "donorId", observations_identifiers=["obsId", "obsId2"])
+        diagnosis_report = _DiagnosisReport("sampleId", "donorId", observations_identifiers=["obsId", "obsId2"])
         self.assertEqual("obsId", diagnosis_report.observations_identifiers[0])
         self.assertEqual("obsId2", diagnosis_report.observations_identifiers[1])
 
     def test_diagnosis_report_multiple_observations_to_fhir_ok(self):
-        diagnosis_report = DiagnosisReport("sampleId", "donorId")
+        diagnosis_report = _DiagnosisReport("sampleId", "donorId")
         diagnosis_report_fhir = diagnosis_report.to_fhir("sampleFhirId", "donorFhirId", ["obsFhirId", "obsFhirId2"])
         self.assertEqual("Patient/donorFhirId", diagnosis_report_fhir.subject.reference)
         self.assertEqual("Specimen/sampleFhirId", diagnosis_report_fhir.specimen[0].reference)
@@ -70,10 +70,10 @@ class TestDiagnosisReport(unittest.TestCase):
         self.assertEqual("final", diagnosis_report_fhir.status)
 
     def test_diagnosis_report_from_json(self):
-        example_diagnosis_report = DiagnosisReport("sampleId", "donorId")
+        example_diagnosis_report = _DiagnosisReport("sampleId", "donorId")
         example_fhir = example_diagnosis_report.to_fhir("sampleFhirId", "donorFhirId", ["obsFhirId", "obsFhirId2"])
         example_fhir.id = "TestFHIRId"
-        diagnosis_report = DiagnosisReport.from_json(example_fhir.as_json(), "sampleId", "donorId")
+        diagnosis_report = _DiagnosisReport.from_json(example_fhir.as_json(), "sampleId", "donorId")
         self.assertEqual(example_diagnosis_report.sample_identifier, diagnosis_report.sample_identifier)
         self.assertEqual("TestFHIRId", diagnosis_report.diagnosis_report_fhir_id)
         self.assertEqual(["obsFhirId", "obsFhirId2"], diagnosis_report.observations_fhir_identifiers)

--- a/test/unit/model/test_network.py
+++ b/test/unit/model/test_network.py
@@ -1,66 +1,86 @@
 import unittest
 
 from miabis_model import Network
+from miabis_model.network_organization import _NetworkOrganization
 
 
 class TestNetwork(unittest.TestCase):
     def test_network_init(self):
-        network = Network("networkId", "networkName", "biobankId", ["collMemID1, collemMemID2"],
-                          ["bioMemID1, bioMemID2"])
+        network = Network(identifier="networkId", name="networkName", managing_biobank_id="managingBiobankId",
+                          contact_email="contactEmail", country="CZ", juristic_person="juristicPerson",
+                          members_collections_ids=["collMemID1, collemMemID2"],
+                          members_biobanks_ids=["bioMemID1, bioMemID2"], contact_name="contactName",
+                          contact_surname="contactSurname", common_collaboration_topics=["Charter"],
+                          description="description")
         self.assertIsInstance(network, Network)
         self.assertEqual("networkId", network.identifier)
         self.assertEqual("networkName", network.name)
+        self.assertEqual("managingBiobankId", network.managing_biobank_id)
+        self.assertEqual("contactEmail", network.contact_email)
+        self.assertEqual("CZ", network.country)
+        self.assertEqual("juristicPerson", network.juristic_person)
         self.assertEqual(["collMemID1, collemMemID2"], network.members_collections_ids)
         self.assertEqual(["bioMemID1, bioMemID2"], network.members_biobanks_ids)
+        self.assertEqual("contactSurname", network.contact_surname)
+        self.assertEqual("contactName", network.contact_name)
+        self.assertEqual(["Charter"], network.common_collaboration_topics)
+        self.assertEqual("description", network.description)
 
     def test_network_invalid_identifier_type_innit(self):
         with self.assertRaises(TypeError):
-            network = Network(37, "networkName", "biobankId")
+            network = Network(identifier=37, name="networkName", managing_biobank_id="managingBiobankId",
+                              contact_email="contactEmail", country="CZ", juristic_person="juristicPerson")
 
     def test_network_invalid_name_type_innit(self):
         with self.assertRaises(TypeError):
-            network = Network("networkId", 22, "biobankId")
+            network = Network(identifier="networkId", name=37, managing_biobank_id="managingBiobankId",
+                              contact_email="contactEmail", country="CZ", juristic_person="juristicPerson")
 
     def test_network_members_collection_ids_invalid_type(self):
         with self.assertRaises(TypeError):
-            network = Network("networkId", "networkName", "biobankId", [5])
+            network = Network(identifier="networkId", name="networkName", managing_biobank_id="managingBiobankId",
+                              contact_email="contactEmail", country="CZ", juristic_person="juristicPerson",
+                              members_collections_ids=[5])
 
     def test_network_members_biobanks_ids_invalid_type(self):
         with self.assertRaises(TypeError):
-            network = Network("networkId", "networkName", "biobankId", ["collid"], [5])
+            network = Network(identifier="networkId", name="networkName", managing_biobank_id="managingBiobankId",
+                              contact_email="contactEmail", country="CZ", juristic_person="juristicPerson",
+                              members_biobanks_ids=[47])
 
     def test_network_set_identifier_ok(self):
-        network = Network("networkId", "networkName", "biobankId", ["Charter"])
+        network = Network(identifier="networkId", name="networkName", managing_biobank_id="managingBiobankId",
+                          contact_email="contactEmail", country="CZ", juristic_person="juristicPerson")
         network.identifier = "newId"
         self.assertEqual("newId", network.identifier)
 
     def test_network_set_identifier_invalid(self):
-        network = Network("networkId", "networkName", "biobankId", ["collid"])
+        network = Network(identifier="networkId", name="networkName", managing_biobank_id="managingBiobankId",
+                          contact_email="contactEmail", country="CZ", juristic_person="juristicPerson")
         with self.assertRaises(TypeError):
             network.identifier = 37
 
     def test_network_set_name_ok(self):
-        network = Network("networkId", "networkName", "biobankId", ["collid"])
+        network = Network(identifier="networkId", name="networkName", managing_biobank_id="managingBiobankId",
+                          contact_email="contactEmail", country="CZ", juristic_person="juristicPerson")
         network.name = "newName"
         self.assertEqual("newName", network.name)
 
     def test_network_set_name_invalid(self):
-        network = Network("networkId", "networkName", "biobankId", ["collid"])
+        network = Network(identifier="networkId", name="networkName", managing_biobank_id="managingBiobankId",
+                          contact_email="contactEmail", country="CZ", juristic_person="juristicPerson")
         with self.assertRaises(TypeError):
             network.name = 37
 
-    def test_network_set_collection_ids_valid(self):
-        network = Network("networkId", "networkName", "biobankId", ["cllid"])
-        network.common_collaboration_topics = ["SOP"]
-        self.assertEqual(["SOP"], network.common_collaboration_topics)
-
     def test_network_set_collection_ids_invalid(self):
-        network = Network("networkId", "networkName", "biobankId", ["collId"])
+        network = Network(identifier="networkId", name="networkName", managing_biobank_id="managingBiobankId",
+                          contact_email="contactEmail", country="CZ", juristic_person="juristicPerson")
         with self.assertRaises(TypeError):
             network.members_collections_ids = [5]
 
     def test_network_to_fhir(self):
-        network = Network("networkId", "networkName", "biobankId", ["collid"])
+        network = Network(identifier="networkId", name="networkName", managing_biobank_id="managingBiobankId",
+                          contact_email="contactEmail", country="CZ", juristic_person="juristicPerson")
         network_fhir = network.to_fhir("biobankFhirId", ["collfhirid1", "collfhirid2"],
                                        ["biobankFhirId1", "biobankFhirId2"])
         self.assertTrue(network_fhir.active)
@@ -73,13 +93,17 @@ class TestNetwork(unittest.TestCase):
         self.assertEqual("Organization/biobankFhirId2", network_fhir.extension[3].valueReference.reference)
 
     def test_network_from_json(self):
-        example_network = Network("networkId", "networkName", "biobankId", ["collid"])
+        example_network = Network(identifier="networkId", name="networkName", managing_biobank_id="managingBiobankId",
+                                  contact_email="contactEmail", country="CZ", juristic_person="juristicPerson")
         example_fhir = example_network.to_fhir("biobankFhirId", ["collfhirid1", "collfhirid2"],
                                                ["biobankFhirId1", "biobankFhirId2"])
         example_fhir.id = "TestFHIRId"
-        network = Network.from_json(example_fhir.as_json(), "biobankId", ["collid1", "collid2"],
+        network_org_fhir = example_network._network_org.to_fhir("biobankFhirId")
+        network_org_fhir.id = "TestNetworkOrgFhirId"
+        network = Network.from_json(example_fhir.as_json(), network_org_fhir.as_json(), "biobankId", ["collid1", "collid2"],
                                     ["biobankid1", "biobankid2"])
         self.assertIsInstance(network, Network)
+        self.assertIsInstance(network._network_org, _NetworkOrganization)
         self.assertEqual(example_network.identifier, network.identifier)
         self.assertEqual(example_network.name, network.name)
         self.assertEqual(example_network.managing_network_org_id, network.managing_network_org_id)

--- a/test/unit/model/test_network_org.py
+++ b/test/unit/model/test_network_org.py
@@ -1,198 +1,285 @@
 import unittest
 
-from miabis_model import NetworkOrganization
+from miabis_model import _NetworkOrganization
 
 
 class TestNetworkOrganization(unittest.TestCase):
     def test_network_org_required_params_init(self):
-        network_org = NetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
-        self.assertIsInstance(network_org, NetworkOrganization)
+        network_org = _NetworkOrganization(identifier="networkOrgId", name="networkName",
+                                           managing_biobank_id="biobankId",
+                                           contact_email="contactEmail", country="CZ", juristic_person="juristicPerson")
+        self.assertIsInstance(network_org, _NetworkOrganization)
         self.assertEqual("networkOrgId", network_org.identifier)
-        self.assertEqual("networkOrgName", network_org.name)
+        self.assertEqual("networkName", network_org.name)
         self.assertEqual("biobankId", network_org.managing_biobank_id)
+        self.assertEqual("contactEmail", network_org.contact_email)
+        self.assertEqual("CZ", network_org.country)
+        self.assertEqual("juristicPerson", network_org.juristic_person)
 
     def test_network_org_optional_params_init(self):
-        network_org = NetworkOrganization("networkOrgId", "networkOrgName", "biobankId", "contactName",
-                                          "contactSurname", "contactEmail", "country", ["Charter"], "juristicPerson")
-        self.assertIsInstance(network_org, NetworkOrganization)
+        network_org = _NetworkOrganization(identifier="networkOrgId", name="networkName",
+                                           managing_biobank_id="biobankId",
+                                           contact_email="contactEmail", country="CZ", juristic_person="juristicPerson",
+                                           contact_name="contactName", contact_surname="contactSurname",
+                                           common_collaboration_topics=["Charter"], description="Description")
+        self.assertIsInstance(network_org, _NetworkOrganization)
         self.assertEqual("networkOrgId", network_org.identifier)
-        self.assertEqual("networkOrgName", network_org.name)
+        self.assertEqual("networkName", network_org.name)
         self.assertEqual("biobankId", network_org.managing_biobank_id)
         self.assertEqual("contactName", network_org.contact_name)
         self.assertEqual("contactSurname", network_org.contact_surname)
         self.assertEqual("contactEmail", network_org.contact_email)
-        self.assertEqual("country", network_org.country)
+        self.assertEqual("CZ", network_org.country)
         self.assertEqual(["Charter"], network_org.common_collaboration_topics)
         self.assertEqual("juristicPerson", network_org.juristic_person)
+        self.assertEqual("Description", network_org.description)
 
     def test_network_org_invalid_identifier_type_innit(self):
         with self.assertRaises(TypeError):
-            network_org = NetworkOrganization(37, "networkOrgName", "biobankId")
+            network_org = _NetworkOrganization(identifier=37, name="networkName",
+                                               managing_biobank_id="biobankId",
+                                               contact_email="contactEmail", country="CZ",
+                                               juristic_person="juristicPerson")
 
     def test_network_org_invalid_name_type_innit(self):
         with self.assertRaises(TypeError):
-            network_org = NetworkOrganization("networkOrgId", 22, "biobankId")
+            network_org = _NetworkOrganization(identifier="networkOrgId", name=37,
+                                               managing_biobank_id="biobankId",
+                                               contact_email="contactEmail", country="CZ",
+                                               juristic_person="juristicPerson")
 
     def test_network_org_invalid_managing_biobank_id_type_innit(self):
         with self.assertRaises(TypeError):
-            network_org = NetworkOrganization("networkOrgId", "networkOrgName", 22)
+            network_org = _NetworkOrganization(identifier="networkOrgId", name="networkName",
+                                               managing_biobank_id=37,
+                                               contact_email="contactEmail", country="CZ",
+                                               juristic_person="juristicPerson")
 
     def test_network_org_invalid_contact_name_type_innit(self):
         with self.assertRaises(TypeError):
-            network_org = NetworkOrganization("networkOrgId", "networkOrgName", "biobankId", 22)
+            network_org = _NetworkOrganization(identifier="networkOrgId", name="networkName",
+                                               managing_biobank_id="biobankId",
+                                               contact_email="contactEmail", country="CZ",
+                                               juristic_person="juristicPerson", contact_name=37)
 
     def test_network_org_invalid_contact_surname_type_innit(self):
         with self.assertRaises(TypeError):
-            network_org = NetworkOrganization("networkOrgId", "networkOrgName", "biobankId", "contactName", 22)
+            network_org = _NetworkOrganization(identifier="networkOrgId", name="networkName",
+                                               managing_biobank_id="biobankId",
+                                               contact_email="contactEmail", country="CZ",
+                                               juristic_person="juristicPerson",
+                                               contact_surname=37)
 
     def test_network_org_invalid_contact_email_type_innit(self):
         with self.assertRaises(TypeError):
-            network_org = NetworkOrganization("networkOrgId", "networkOrgName", "biobankId", "contactName",
-                                              "contactSurname", 22)
+            network_org = _NetworkOrganization(identifier="networkOrgId", name="networkName",
+                                               managing_biobank_id="biobankId",
+                                               contact_email=37, country="CZ", juristic_person="juristicPerson")
 
     def test_network_org_invalid_country_type_innit(self):
         with self.assertRaises(TypeError):
-            network_org = NetworkOrganization("networkOrgId", "networkOrgName", "biobankId", "contactName",
-                                              "contactSurname", "contactEmail", 22)
+            network_org = _NetworkOrganization(identifier="networkOrgId", name="networkName",
+                                               managing_biobank_id="biobankId",
+                                               contact_email="contactEmail", country=37,
+                                               juristic_person="juristicPerson")
 
     def test_network_org_invalid_common_collaboration_topics_type_innit(self):
         with self.assertRaises(TypeError):
-            network_org = NetworkOrganization("networkOrgId", "networkOrgName", "biobankId", "contactName",
-                                              "contactSurname", "contactEmail", "country", 22)
+            network_org = _NetworkOrganization(identifier="networkOrgId", name="networkName",
+                                               managing_biobank_id="biobankId",
+                                               contact_email="contactEmail", country="CZ",
+                                               juristic_person="juristicPerson",
+                                               common_collaboration_topics=37)
 
     def test_network_org_invalid_common_collaboration_topics_value_innit(self):
         with self.assertRaises(ValueError):
-            network_org = NetworkOrganization("networkOrgId", "networkOrgName", "biobankId", "contactName",
-                                              "contactSurname", "contactEmail", "country", ["invalidTopic"])
+            network_org = _NetworkOrganization(identifier="networkOrgId", name="networkName",
+                                               managing_biobank_id="biobankId",
+                                               contact_email="contactEmail", country="CZ",
+                                               juristic_person="juristicPerson",
+                                               common_collaboration_topics=["invalid"])
 
     def test_network_org_invalid_juristic_person_type_innit(self):
         with self.assertRaises(TypeError):
-            network_org = NetworkOrganization("networkOrgId", "networkOrgName", "biobankId", "contactName",
-                                              "contactSurname", "contactEmail", "country", ["Charter"], 22)
+            network_org = _NetworkOrganization(identifier="networkOrgId", name="networkName",
+                                               managing_biobank_id="biobankId",
+                                               contact_email="contactEmail", country="CZ", juristic_person=37)
 
     def test_network_org_set_identifier_ok(self):
-        network_org = NetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        network_org = _NetworkOrganization(identifier="networkOrgId", name="networkName",
+                                           managing_biobank_id="biobankId",
+                                           contact_email="contactEmail", country="CZ", juristic_person="juristicPerson")
         network_org.identifier = "newId"
         self.assertEqual("newId", network_org.identifier)
 
     def test_network_org_set_identifier_invalid(self):
-        network_org = NetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        network_org = _NetworkOrganization(identifier="networkOrgId", name="networkName",
+                                           managing_biobank_id="biobankId",
+                                           contact_email="contactEmail", country="CZ", juristic_person="juristicPerson")
         with self.assertRaises(TypeError):
             network_org.identifier = 37
 
     def test_network_org_set_name_ok(self):
-        network_org = NetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        network_org = _NetworkOrganization(identifier="networkOrgId", name="networkName",
+                                           managing_biobank_id="biobankId",
+                                           contact_email="contactEmail", country="CZ", juristic_person="juristicPerson")
         network_org.name = "newName"
         self.assertEqual("newName", network_org.name)
 
     def test_network_org_set_name_invalid(self):
-        network_org = NetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        network_org = _NetworkOrganization(identifier="networkOrgId", name="networkName",
+                                           managing_biobank_id="biobankId",
+                                           contact_email="contactEmail", country="CZ", juristic_person="juristicPerson")
         with self.assertRaises(TypeError):
             network_org.name = 37
 
     def test_network_org_set_managing_biobank_id_ok(self):
-        network_org = NetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        network_org = _NetworkOrganization(identifier="networkOrgId", name="networkName",
+                                           managing_biobank_id="biobankId",
+                                           contact_email="contactEmail", country="CZ", juristic_person="juristicPerson")
         network_org.managing_biobank_id = "newId"
         self.assertEqual("newId", network_org.managing_biobank_id)
 
     def test_network_org_set_managing_biobank_id_invalid(self):
-        network_org = NetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        network_org = _NetworkOrganization(identifier="networkOrgId", name="networkName",
+                                           managing_biobank_id="biobankId",
+                                           contact_email="contactEmail", country="CZ", juristic_person="juristicPerson")
         with self.assertRaises(TypeError):
             network_org.managing_biobank_id = 37
 
     def test_network_org_set_contact_name_ok(self):
-        network_org = NetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        network_org = _NetworkOrganization(identifier="networkOrgId", name="networkName",
+                                           managing_biobank_id="biobankId",
+                                           contact_email="contactEmail", country="CZ", juristic_person="juristicPerson")
         network_org.contact_name = "newName"
         self.assertEqual("newName", network_org.contact_name)
 
     def test_network_org_set_contact_name_invalid(self):
-        network_org = NetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        network_org = _NetworkOrganization(identifier="networkOrgId", name="networkName",
+                                           managing_biobank_id="biobankId",
+                                           contact_email="contactEmail", country="CZ", juristic_person="juristicPerson")
         with self.assertRaises(TypeError):
             network_org.contact_name = 37
 
     def test_network_org_set_contact_surname_ok(self):
-        network_org = NetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        network_org = _NetworkOrganization(identifier="networkOrgId", name="networkName",
+                                           managing_biobank_id="biobankId",
+                                           contact_email="contactEmail", country="CZ", juristic_person="juristicPerson")
         network_org.contact_surname = "newName"
         self.assertEqual("newName", network_org.contact_surname)
 
     def test_network_org_set_contact_surname_invalid(self):
-        network_org = NetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        network_org = _NetworkOrganization(identifier="networkOrgId", name="networkName",
+                                           managing_biobank_id="biobankId",
+                                           contact_email="contactEmail", country="CZ", juristic_person="juristicPerson")
         with self.assertRaises(TypeError):
             network_org.contact_surname = 37
 
     def test_network_org_set_contact_email_ok(self):
-        network_org = NetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        network_org = _NetworkOrganization(identifier="networkOrgId", name="networkName",
+                                           managing_biobank_id="biobankId",
+                                           contact_email="contactEmail", country="CZ", juristic_person="juristicPerson")
         network_org.contact_email = "newName"
         self.assertEqual("newName", network_org.contact_email)
 
     def test_network_org_set_contact_email_invalid(self):
-        network_org = NetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        network_org = _NetworkOrganization(identifier="networkOrgId", name="networkName",
+                                           managing_biobank_id="biobankId",
+                                           contact_email="contactEmail", country="CZ", juristic_person="juristicPerson")
         with self.assertRaises(TypeError):
             network_org.contact_email = 37
 
     def test_network_org_set_country_ok(self):
-        network_org = NetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        network_org = _NetworkOrganization(identifier="networkOrgId", name="networkName",
+                                           managing_biobank_id="biobankId",
+                                           contact_email="contactEmail", country="CZ", juristic_person="juristicPerson")
         network_org.country = "newName"
         self.assertEqual("newName", network_org.country)
 
     def test_network_org_set_country_invalid(self):
-        network_org = NetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        network_org = _NetworkOrganization(identifier="networkOrgId", name="networkName",
+                                           managing_biobank_id="biobankId",
+                                           contact_email="contactEmail", country="CZ", juristic_person="juristicPerson")
         with self.assertRaises(TypeError):
             network_org.country = 37
 
     def test_network_org_set_common_collaboration_topics_valid(self):
-        network_org = NetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        network_org = _NetworkOrganization(identifier="networkOrgId", name="networkName",
+                                           managing_biobank_id="biobankId",
+                                           contact_email="contactEmail", country="CZ", juristic_person="juristicPerson")
         network_org.common_collaboration_topics = ["SOP"]
         self.assertEqual(["SOP"], network_org.common_collaboration_topics)
 
     def test_network_org_set_common_collaboration_topics_invalid(self):
-        network_org = NetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        network_org = _NetworkOrganization(identifier="networkOrgId", name="networkName",
+                                           managing_biobank_id="biobankId",
+                                           contact_email="contactEmail", country="CZ", juristic_person="juristicPerson")
         with self.assertRaises(TypeError):
             network_org.common_collaboration_topics = 33
 
     def test_network_org_set_common_collaboration_topics_invalid_value(self):
-        network_org = NetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        network_org = _NetworkOrganization(identifier="networkOrgId", name="networkName",
+                                           managing_biobank_id="biobankId",
+                                           contact_email="contactEmail", country="CZ", juristic_person="juristicPerson")
         with self.assertRaises(ValueError):
             network_org.common_collaboration_topics = ["invalidTopic"]
 
     def test_network_org_set_juristic_person_ok(self):
-        network_org = NetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        network_org = _NetworkOrganization(identifier="networkOrgId", name="networkName",
+                                           managing_biobank_id="biobankId",
+                                           contact_email="contactEmail", country="CZ", juristic_person="juristicPerson")
         network_org.juristic_person = "newName"
         self.assertEqual("newName", network_org.juristic_person)
 
     def test_network_org_set_juristic_person_invalid(self):
-        network_org = NetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        network_org = _NetworkOrganization(identifier="networkOrgId", name="networkName",
+                                           managing_biobank_id="biobankId",
+                                           contact_email="contactEmail", country="CZ", juristic_person="juristicPerson")
         with self.assertRaises(TypeError):
             network_org.juristic_person = 37
 
     def test_network_org_to_fhir(self):
-        network_org = NetworkOrganization("networkOrgId", "networkOrgName", "biobankId")
+        network_org = _NetworkOrganization(identifier="networkOrgId", name="networkName",
+                                           managing_biobank_id="biobankId",
+                                           contact_email="contactEmail", country="CZ", juristic_person="juristicPerson")
         network_org_fhir = network_org.to_fhir("biobankFhirId")
         self.assertEqual("networkOrgId", network_org_fhir.identifier[0].value)
-        self.assertEqual("networkOrgName", network_org_fhir.name)
+        self.assertEqual("networkName",network_org_fhir.name)
+        self.assertEqual("contactEmail", network_org_fhir.contact[0].telecom[0].value)
+        self.assertEqual("CZ", network_org_fhir.address[0].country)
         self.assertEqual("Organization/biobankFhirId", network_org_fhir.partOf.reference)
+        self.assertEqual("juristicPerson", network_org_fhir.extension[0].valueString)
 
     def test_network_org_to_fhir_optional_params(self):
-        network_org = NetworkOrganization("networkOrgId", "networkOrgName", "biobankId", "contactName",
-                                          "contactSurname", "contactEmail", "country", ["Charter"], "juristicPerson")
+        network_org = _NetworkOrganization(identifier="networkOrgId", name="networkName",
+                                           managing_biobank_id="biobankId",
+                                           contact_email="contactEmail", country="CZ", juristic_person="juristicPerson",
+                                           contact_name="contactName", contact_surname="contactSurname",
+                                           common_collaboration_topics=["Charter"],
+                                           description="description")
         network_org_fhir = network_org.to_fhir("biobankFhirId")
         self.assertEqual("networkOrgId", network_org_fhir.identifier[0].value)
-        self.assertEqual("networkOrgName", network_org_fhir.name)
+        self.assertEqual("networkName", network_org_fhir.name)
         self.assertEqual("Organization/biobankFhirId", network_org_fhir.partOf.reference)
         self.assertEqual("contactName", network_org_fhir.contact[0].name.given[0])
         self.assertEqual("contactSurname", network_org_fhir.contact[0].name.family)
         self.assertEqual("contactEmail", network_org_fhir.contact[0].telecom[0].value)
-        self.assertEqual("country", network_org_fhir.address[0].country)
+        self.assertEqual("CZ", network_org_fhir.address[0].country)
         self.assertEqual("Charter", network_org_fhir.extension[0].valueCodeableConcept.coding[0].code)
         self.assertEqual("juristicPerson", network_org_fhir.extension[1].valueString)
+        self.assertEqual("description", network_org_fhir.extension[2].valueString)
 
     def test_network_org_from_json(self):
-        example_network = NetworkOrganization("networkOrgId", "networkOrgName", "biobankId", "contactName",
-                                              "contactSurname", "contactEmail", "country", ["Charter"],
-                                              "juristicPerson")
+        example_network = _NetworkOrganization(identifier="networkOrgId", name="networkName",
+                                               managing_biobank_id="biobankId",
+                                               contact_email="contactEmail", country="CZ",
+                                               juristic_person="juristicPerson",
+                                               contact_name="contactName", contact_surname="contactSurname",
+                                               common_collaboration_topics=["Charter"],
+                                               description="description")
         example_fhir = example_network.to_fhir("biobankFhirId")
         example_fhir.id = "TestFHIRId"
-        network_org = NetworkOrganization.from_json(example_fhir.as_json(), "biobankId")
+        network_org = _NetworkOrganization.from_json(example_fhir.as_json(), "biobankId")
         self.assertEqual(example_network.identifier, network_org.identifier)
         self.assertEqual(example_network.name, network_org.name)
         self.assertEqual(example_network.managing_biobank_id, network_org.managing_biobank_id)

--- a/test/unit/model/test_observation.py
+++ b/test/unit/model/test_observation.py
@@ -1,46 +1,46 @@
 import datetime
 import unittest
 
-from miabis_model.observation import Observation
+from miabis_model.observation import _Observation
 
 
 class TestObservation(unittest.TestCase):
     def test_observation_args_ok(self):
-        observation = Observation("C51", "sampleId", "patientId")
-        self.assertIsInstance(observation, Observation)
+        observation = _Observation("C51", "sampleId", "patientId")
+        self.assertIsInstance(observation, _Observation)
         self.assertEqual("C51", observation.icd10_code)
         self.assertEqual("sampleId", observation.sample_identifier)
 
     def test_observation_invalid_icd10_code_value_innit(self):
         with self.assertRaises(ValueError):
-            Observation("C0000", "sampleId", "patientId")
+            _Observation("C0000", "sampleId", "patientId")
 
     def test_observation_invalid_sample_identifier_type_innit(self):
         with self.assertRaises(TypeError):
-            Observation("C51", 37, "patientId")
+            _Observation("C51", 37, "patientId")
 
     def test_observation_set_icd10_code_ok(self):
-        observation = Observation("C51", "sampleId", "patientId")
+        observation = _Observation("C51", "sampleId", "patientId")
         observation.icd10_code = "C50"
         self.assertEqual("C50", observation.icd10_code)
 
     def test_observation_set_icd10_code_invalid(self):
-        observation = Observation("C51", "sampleId", "patientId")
+        observation = _Observation("C51", "sampleId", "patientId")
         with self.assertRaises(ValueError):
             observation.icd10_code = "C0000"
 
     def test_observation_set_sample_identifier_ok(self):
-        observation = Observation("C51", "sampleId", "patientId")
+        observation = _Observation("C51", "sampleId", "patientId")
         observation.sample_identifier = "newId"
         self.assertEqual("newId", observation.sample_identifier)
 
     def test_observation_set_sample_identifier_invalid(self):
-        observation = Observation("C51", "sampleId", "patientId")
+        observation = _Observation("C51", "sampleId", "patientId")
         with self.assertRaises(TypeError):
             observation.sample_identifier = 37
 
     def test_observation_to_fhir_ok(self):
-        observation = Observation("C51", "sampleId", "patientId", datetime.datetime(year=2022, month=10, day=10),
+        observation = _Observation("C51", "sampleId", "patientId", datetime.datetime(year=2022, month=10, day=10),
                                   "obsId")
         obs_fhir = observation.to_fhir("patientFhirId", "sampleFhirId")
         self.assertEqual("C51", obs_fhir.valueCodeableConcept.coding[0].code)
@@ -51,11 +51,11 @@ class TestObservation(unittest.TestCase):
         self.assertEqual(datetime.datetime(year=2022, month=10, day=10).date(), obs_fhir.effectiveDateTime.date)
 
     def test_observation_from_json(self):
-        example_observation = Observation("C51", "sampleId", "patientId",
-                                          datetime.datetime(year=2022, month=10, day=10))
+        example_observation = _Observation("C51", "sampleId", "patientId",
+                                           datetime.datetime(year=2022, month=10, day=10))
         example_fhir = example_observation.to_fhir("patientFhirId", "sampleFhirId")
         example_fhir.id = "TestFHIRId"
-        observation = Observation.from_json(example_fhir.as_json(), "patientId", "sampleId")
+        observation = _Observation.from_json(example_fhir.as_json(), "patientId", "sampleId")
         self.assertEqual(example_observation.icd10_code, observation.icd10_code)
         self.assertEqual(example_observation.sample_identifier, observation.sample_identifier)
         self.assertEqual(example_observation.patient_identifier, observation.patient_identifier)


### PR DESCRIPTION
Changes of blaze client and miabis model aswell. Make Observation, Diagnostic report, Collection Organization and NetworkOrganization private. Make it so that the Sample uses diagnostic report and observation inside itself, so the user does not need to work with these clasyes, resulting in less complex library.