### PR TITLE
fix: align canonical URLs with the published IG (remove /fhir/ from BASE_URL)

### DIFF
--- a/SearchParamBundle.json
+++ b/SearchParamBundle.json
@@ -8,7 +8,7 @@
       "resource": {
         "resourceType": "SearchParameter",
         "id": "ExtensionMemberEntitySearch",
-        "url": "https://fhir.bbmri-eric.eu/fhir/SearchParameter/GroupMember",
+        "url": "https://fhir.bbmri-eric.eu/SearchParameter/GroupMember",
         "base": [
           "Group"
         ],
@@ -47,7 +47,7 @@
         "experimental": false,
         "code": "sample-collection-id",
         "type": "token",
-        "expression": "Specimen.extension('https://fhir.bbmri-eric.eu/fhir/StructureDefinition/miabis-sample-collection-extension').value as Identifier",
+        "expression": "Specimen.extension('https://fhir.bbmri-eric.eu/StructureDefinition/miabis-sample-collection-extension').value as Identifier",
         "xpathUsage": "normal"
       }
     }

--- a/miabis_model/util/config.py
+++ b/miabis_model/util/config.py
@@ -1,5 +1,5 @@
 class FHIRConfig:
-    BASE_URL = "https://fhir.bbmri-eric.eu/fhir"
+    BASE_URL = "https://fhir.bbmri-eric.eu"
 
     MEMBER_V5_EXTENSION = "http://hl7.org/fhir/5.0/StructureDefinition/extension-Group.member.entity"
     DIAGNOSIS_CODE_SYSTEM = "http://hl7.org/fhir/sid/icd-10"
@@ -123,7 +123,7 @@ class FHIRConfig:
             "bioprocessing_and_analysis_capabilities": "/StructureDefinition/miabis-bioprocessing-and-analytical-capabilities-extension",
             "quality_management_standard": "/StructureDefinition/miabis-quality-management-standard-extension",
             "juristic_person": "/StructureDefinition/miabis-juristic-person-extension",
-            "description": "/fhir/StructureDefinition/miabis-organization-description-extension"
+            "description": "/StructureDefinition/miabis-organization-description-extension"
         },
         "code_systems": {
             "infrastructural_capabilities": "/CodeSystem/miabis-infrastructural-capabilities-cs",

--- a/miabis_model/util/constants.py
+++ b/miabis_model/util/constants.py
@@ -1,4 +1,4 @@
-DEFINITION_BASE_URL = "https://fhir.bbmri-eric.eu/fhir"
+DEFINITION_BASE_URL = "https://fhir.bbmri-eric.eu"
 
 DETAILED_MATERIAL_TYPE_CODES = ["AmnioticFluid", "AscitesFluid", "Bile", "BodyCavityFluid", "Bone",
                                 "BoneMarrowAspirate", "BoneMarrowPlasma", "BoneMarrowWhole", "BreastMilk",

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -1,0 +1,47 @@
+import unittest
+
+from miabis_model.util.config import FHIRConfig
+from miabis_model.util.constants import DEFINITION_BASE_URL
+
+IG_CANONICAL_ROOT = "https://fhir.bbmri-eric.eu"
+
+
+class TestCanonicalUrls(unittest.TestCase):
+    def test_base_url_constants_match_ig_root(self):
+        self.assertEqual(IG_CANONICAL_ROOT, FHIRConfig.BASE_URL)
+        self.assertEqual(IG_CANONICAL_ROOT, DEFINITION_BASE_URL)
+
+    def test_sample_profile_matches_ig_canonical(self):
+        self.assertEqual(f"{IG_CANONICAL_ROOT}/StructureDefinition/miabis-sample",
+                         FHIRConfig.get_meta_profile_url("sample"))
+
+    def test_sample_extensions_match_ig_canonical(self):
+        self.assertEqual(
+            f"{IG_CANONICAL_ROOT}/StructureDefinition/miabis-sample-collection-extension",
+            FHIRConfig.get_extension_url("sample", "sample_collection_id"))
+        self.assertEqual(
+            f"{IG_CANONICAL_ROOT}/StructureDefinition/miabis-sample-storage-temperature-extension",
+            FHIRConfig.get_extension_url("sample", "storage_temperature"))
+
+    def test_detailed_sample_type_code_system_matches_ig_canonical(self):
+        self.assertEqual(
+            f"{IG_CANONICAL_ROOT}/CodeSystem/miabis-detailed-samply-type-cs",
+            FHIRConfig.get_code_system_url("sample", "detailed_sample_type"))
+
+    def test_biobank_description_extension_matches_ig_canonical(self):
+        self.assertEqual(
+            f"{IG_CANONICAL_ROOT}/StructureDefinition/miabis-organization-description-extension",
+            FHIRConfig.get_extension_url("biobank", "description"))
+
+    def test_no_profile_or_extension_url_contains_fhir_segment(self):
+        for dict_name in [name for name in dir(FHIRConfig) if name.endswith("_URLS")]:
+            resource_name = dict_name[: -len("_URLS")].lower()
+            profile_url = FHIRConfig.get_meta_profile_url(resource_name)
+            if profile_url is not None:
+                self.assertNotIn("/fhir/", profile_url)
+            for extension_name in getattr(FHIRConfig, dict_name).get("extensions", {}):
+                self.assertNotIn("/fhir/", FHIRConfig.get_extension_url(resource_name, extension_name))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`FHIRConfig.BASE_URL` (and the duplicate `DEFINITION_BASE_URL`) included a `/fhir/`
segment, so every emitted `meta.profile`, extension, value-set and code-system URL
took the form `https://fhir.bbmri-eric.eu/fhir/StructureDefinition/miabis-sample`.

The published MIABIS-on-FHIR IG (https://fhir.miabis.bbmri-eric.eu/) declares these
canonicals **without** the `/fhir/` segment — e.g.
`https://fhir.bbmri-eric.eu/StructureDefinition/miabis-sample`. This matches the FSH
source in `BBMRI-cz/miabis-on-fhir` (`sushi-config.yaml`: `canonical:
https://fhir.bbmri-eric.eu`).

As a result, resources produced by the library carry profile/extension URLs that the
IG validator cannot resolve, and downstream consumers that derive URLs from the IG
(e.g. `samply/focus` with `CQL_FLAVOUR=miabis`) do not match them.

## Changes

- `config.py` / `constants.py`: drop `/fhir/` from `FHIRConfig.BASE_URL` and
  `DEFINITION_BASE_URL`.
- `config.py`: remove a stray `/fhir/` from the `BIOBANK_URLS` `description`
  extension path. With the old `BASE_URL` it produced a doubled
  `…/fhir/fhir/StructureDefinition/…`, and it diverged from the two sibling
  organization URLs (`COLLECTION_ORGANIZATION_URLS`, `NETWORK_ORGANIZATION_URLS`)
  that reference the same extension without the segment. IG canonical confirmed:
  `https://fhir.bbmri-eric.eu/StructureDefinition/miabis-organization-description-extension`.
- `SearchParamBundle.json`: update the GroupMember SearchParameter `url` and the
  sample-collection-extension FHIRPath to the no-`/fhir/` URLs, keeping the
  integration-test fixture consistent with library output.
- `test/unit/test_config.py`: new tests pinning the emitted canonicals to the IG
  (profile, sample extensions, detailed-sample-type code system, the biobank
  description extension, and a sweep asserting no profile/extension URL contains
  `/fhir/`).

## Verification

- `make test` — all unit tests pass, including the new `test_config.py`.
- `make integration` — all `test/service` tests pass against
  `samply/blaze:latest` with the updated `SearchParamBundle.json`.
  `test_get_resource_by_search_parameter` is the end-to-end check: it returns
  entries only when the `sample-collection-id` search parameter's FHIRPath
  matches the extension URL the library emits, which now agree on the
  no-`/fhir/` form.
- The new tests fail against the pre-fix constants, confirming they guard the
  regression.

## Note

`BASE_URL` and `DEFINITION_BASE_URL` are duplicate constants; consolidating them is
out of scope here but worth a follow-up.
